### PR TITLE
copy .js and .wasm from node_mosules

### DIFF
--- a/decls/x-img-diff-js.js
+++ b/decls/x-img-diff-js.js
@@ -1,0 +1,4 @@
+declare module 'x-img-diff-js' {
+  declare function getBrowserJsPath(): string;
+  declare function getBrowserWasmPath(): string;
+}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "md5-file": "^3.1.1",
     "meow": "^3.7.0",
     "mustache": "^2.3.0",
-    "x-img-diff-js": "^0.3.2"
+    "x-img-diff-js": "0.3.4"
   },
   "devDependencies": {
     "ava": "^0.22.0",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "watch": "babel src --watch -d dist",
     "build": "npm run build:cli && npm run build:report",
     "build:cli": "babel src -d dist",
-    "build:report": "npm run copy:ximgdiff && webpack",
-    "dev:report": "webpack-dev-server --hot --inline --open",
+    "build:report": "webpack",
+    "dev:report": "npm run copy:ximgdiff && webpack-dev-server --hot --inline --open",
     "flow": "flow",
     "copy:ximgdiff": "copyfiles -u 3 node_modules/x-img-diff-js/build/cv-wasm_browser.* report/assets",
     "prepublish": "npm run build",
@@ -38,7 +38,7 @@
     "md5-file": "^3.1.1",
     "meow": "^3.7.0",
     "mustache": "^2.3.0",
-    "x-img-diff-js": "^0.2.2"
+    "x-img-diff-js": "^0.3.2"
   },
   "devDependencies": {
     "ava": "^0.22.0",

--- a/src/report.js
+++ b/src/report.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import Mustache from 'mustache';
+import * as detectDiff from 'x-img-diff-js';
 import fs from 'fs';
 import mkdirp from 'mkdirp';
 import path from 'path';
@@ -79,7 +80,7 @@ const createHTMLReport = (params) => {
 function createXimdiffWorker(params: ReportParams) {
   const file = path.join(__dirname, '../template/worker_pre.js');
   const moduleJs = fs.readFileSync(path.join(__dirname, '../report/dist/worker.js'), 'utf8');
-  const wasmLoaderJs = fs.readFileSync(path.join(__dirname, '../report/assets/cv-wasm_browser.js'), 'utf8');
+  const wasmLoaderJs = fs.readFileSync(detectDiff.getBrowserJsPath(), 'utf8');
   const template = fs.readFileSync(file);
   const ximgdiffWasmUrl = `${params.urlPrefix}detector.wasm`;
   return Mustache.render(template.toString(), { ximgdiffWasmUrl }) + '\n' + moduleJs + '\n' + wasmLoaderJs;
@@ -93,7 +94,7 @@ export default (params: ReportParams) => {
     if (!!params.enableClientAdditionalDetection) {
       const workerjs = createXimdiffWorker(params);
       fs.writeFileSync(path.resolve(path.dirname(params.report), 'worker.js'), workerjs);
-      const wasmBuf = fs.readFileSync(path.resolve(__dirname, '../report/assets/cv-wasm_browser.wasm'));
+      const wasmBuf = fs.readFileSync(detectDiff.getBrowserWasmPath());
       fs.writeFileSync(path.resolve(path.dirname(params.report), 'detector.wasm'), wasmBuf);
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6371,9 +6371,9 @@ write-pkg@^3.1.0:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
 
-x-img-diff-js@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/x-img-diff-js/-/x-img-diff-js-0.2.2.tgz#3d504348ea8959b98a10330a6c36a773a9e0a2f3"
+x-img-diff-js@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/x-img-diff-js/-/x-img-diff-js-0.3.2.tgz#f552086cf2da28348562f1b4537f26bfb4e1e298"
 
 xdg-basedir@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6371,9 +6371,9 @@ write-pkg@^3.1.0:
     sort-keys "^2.0.0"
     write-json-file "^2.2.0"
 
-x-img-diff-js@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/x-img-diff-js/-/x-img-diff-js-0.3.2.tgz#f552086cf2da28348562f1b4537f26bfb4e1e298"
+x-img-diff-js@0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/x-img-diff-js/-/x-img-diff-js-0.3.4.tgz#ccd406130c90ee82113ced8b55354fc9342b7112"
 
 xdg-basedir@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
What I did:

- Update x-img-diff-js. 
  - reducing .wasm file size (3.2 MB -> 1.4 MB ) 🎉 
  - create functions to tell .js / .wasm absolute paths

And I've amended report.js to use the above functions. So we get free from exec `yarn upgrade x-img-diff-js`. From now, I amend x-img-diff logic and re-build x-img-diff-js, and users can build their reports using the latest x-img-diff via `reg-cli` 😄 