### PR TITLE
fix: Improve modal UX on report view

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "vue-lazyload": "^1.0.3",
     "vue-loader": "~12.2.2",
     "vue-template-compiler": "^2.3.3",
-    "vue-thin-modal": "^0.2.5",
+    "vue-thin-modal": "^0.3.0",
     "webpack": "~3.10.0",
     "webpack-dev-server": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "vue-template-compiler": "^2.3.3",
     "vue-thin-modal": "^0.3.0",
     "webpack": "~3.10.0",
-    "webpack-dev-server": "^3.0.0"
+    "webpack-dev-server": "^2.11.2"
   },
   "files": [
     "dist",

--- a/report/src/App.vue
+++ b/report/src/App.vue
@@ -113,7 +113,6 @@ module.exports = {
     modalSrc: "",
     modalBgSrc: null,
     isModalOpen: false,
-    scrollTop: 0,
     failedItems: searchItems('failedItems', getSearchParams()),
     passedItems: searchItems('passedItems', getSearchParams()),
     newItems: searchItems('newItems', getSearchParams()),
@@ -144,7 +143,6 @@ module.exports = {
       this.modalSrc = src;
       this.modalBgSrc = bg;
       this.isModalOpen = true;
-      this.scrollTop = window.pageYOffset;
       this.$modal.push('capture')
     },
 
@@ -158,7 +156,6 @@ module.exports = {
         expectedSrc: this.selectedSrcExpected
       });
       this.isModalOpen = true;
-      this.scrollTop = window.pageYOffset;
       this.$modal.push('comparison')
     },
 
@@ -168,9 +165,6 @@ module.exports = {
       this.selectedSrcActual = "";
       this.selectedSrcExpected = "";
       this.selectedMatchingResult = null;
-      setTimeout(() => {
-        window.scrollTo(0, this.scrollTop);
-      }, 400);
     },
 
     inputSearch(e) {

--- a/report/src/App.vue
+++ b/report/src/App.vue
@@ -15,7 +15,6 @@
         </div>
       </div>
     </div>
-    <div class="backdrop" v-if="isModalOpen" @click="close"></div>
     <div class="content">
       <div class="not-found" v-if="isNotFound">
         <div>

--- a/report/src/views/CaptureModal.vue
+++ b/report/src/views/CaptureModal.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <modal name="capture" disable-backdrop>
+    <modal name="capture">
       <div class="wrapper">
         <div class="modal">
           <img :src="src" />

--- a/report/src/views/CaptureModal.vue
+++ b/report/src/views/CaptureModal.vue
@@ -72,7 +72,7 @@ img {
 }
 
 .modal-backdrop-enter,
-.modal-backdrop-leave-active {
+.modal-backdrop-leave-to {
   opacity: 0;
 }
 
@@ -96,18 +96,14 @@ img {
   pointer-events: none;
 }
 
-.modal-content-enter-active {
+.modal-content-enter-active,
+.modal-content-leave-active {
   transition: 200ms cubic-bezier(0.51, 0.21, 0.38, 0.98);
   transition-property: opacity, transform;
 }
 
-.modal-content-leave-active {
-  transition: 0ms cubic-bezier(0.51, 0.21, 0.38, 0.98);
-  transition-property: opacity, transform;
-}
-
 .modal-content-enter,
-.modal-content-leave-active {
+.modal-content-leave-to {
   opacity: 0;
   transform: translateY(-50px);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,6 +44,15 @@
   dependencies:
     arrify "^1.0.1"
 
+"@ladjs/time-require@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@ladjs/time-require/-/time-require-0.1.4.tgz#5c615d75fd647ddd5de9cf6922649558856b21a1"
+  dependencies:
+    chalk "^0.4.0"
+    date-time "^0.1.1"
+    pretty-ms "^0.2.1"
+    text-table "^0.2.0"
+
 "@types/node@^6.0.46":
   version "6.0.88"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.88.tgz#f618f11a944f6a18d92b5c472028728a3e3d4b66"
@@ -442,14 +451,15 @@ ava@^0.22.0:
     unique-temp-dir "^1.0.0"
     update-notifier "^2.1.0"
 
-ava@^0.24.0:
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/ava/-/ava-0.24.0.tgz#dd0ab33a0b3ad2ac582f55e9a61caf8bcf7a9af1"
+ava@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/ava/-/ava-0.25.0.tgz#8ac87780514f96a6fd42e1306eaa0752ce3a407f"
   dependencies:
     "@ava/babel-preset-stage-4" "^1.1.0"
     "@ava/babel-preset-transform-test-files" "^3.0.0"
     "@ava/write-file-atomic" "^2.2.0"
     "@concordance/react" "^1.0.0"
+    "@ladjs/time-require" "^0.1.4"
     ansi-escapes "^3.0.0"
     ansi-styles "^3.1.0"
     arr-flatten "^1.0.1"
@@ -471,10 +481,10 @@ ava@^0.24.0:
     cli-spinners "^1.0.0"
     cli-truncate "^1.0.0"
     co-with-promise "^4.6.0"
-    code-excerpt "^2.1.0"
+    code-excerpt "^2.1.1"
     common-path-prefix "^1.0.0"
     concordance "^3.0.0"
-    convert-source-map "^1.2.0"
+    convert-source-map "^1.5.1"
     core-assert "^0.2.0"
     currently-unhandled "^0.4.1"
     debug "^3.0.1"
@@ -496,7 +506,6 @@ ava@^0.24.0:
     is-obj "^1.0.0"
     is-observable "^1.0.0"
     is-promise "^2.1.0"
-    js-yaml "^3.8.2"
     last-line-stream "^1.0.0"
     lodash.clonedeepwith "^4.5.0"
     lodash.debounce "^4.0.3"
@@ -524,8 +533,8 @@ ava@^0.24.0:
     stack-utils "^1.0.1"
     strip-ansi "^4.0.0"
     strip-bom-buf "^1.0.0"
+    supertap "^1.0.0"
     supports-color "^5.0.0"
-    time-require "^0.1.2"
     trim-off-newlines "^1.0.1"
     unique-temp-dir "^1.0.0"
     update-notifier "^2.3.0"
@@ -1767,14 +1776,6 @@ cliui@^3.2.0:
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
 
-cliui@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.0.0.tgz#743d4650e05f36d1ed2575b59638d87322bfbbcc"
-  dependencies:
-    string-width "^2.1.1"
-    strip-ansi "^4.0.0"
-    wrap-ansi "^2.0.0"
-
 clone@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.2.tgz#260b7a99ebb1edfe247538175f783243cb19d149"
@@ -1798,6 +1799,12 @@ coa@~1.0.1:
 code-excerpt@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/code-excerpt/-/code-excerpt-2.1.0.tgz#5dcc081e88f4a7e3b554e9e35d7ef232d47f8147"
+  dependencies:
+    convert-to-spaces "^1.0.1"
+
+code-excerpt@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/code-excerpt/-/code-excerpt-2.1.1.tgz#5fe3057bfbb71a5f300f659ef2cc0a47651ba77c"
   dependencies:
     convert-to-spaces "^1.0.1"
 
@@ -1979,6 +1986,10 @@ content-type@~1.0.4:
 convert-source-map@^1.2.0, convert-source-map@^1.3.0, convert-source-map@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
+
+convert-source-map@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
 convert-to-spaces@^1.0.1:
   version "1.0.2"
@@ -3597,7 +3608,7 @@ indent-string@^2.1.0:
   dependencies:
     repeating "^2.0.0"
 
-indent-string@^3.0.0, indent-string@^3.1.0:
+indent-string@^3.0.0, indent-string@^3.1.0, indent-string@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
 
@@ -4023,6 +4034,13 @@ js-string-escape@^1.0.1:
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+
+js-yaml@^3.10.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
 
 js-yaml@^3.4.3, js-yaml@^3.8.2:
   version "3.9.1"
@@ -6201,6 +6219,10 @@ send@0.16.1:
     range-parser "~1.2.0"
     statuses "~1.3.1"
 
+serialize-error@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-2.1.0.tgz#50b679d5635cdf84667bdc8e59af4e5b81d5f60a"
+
 serialize-javascript@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.4.0.tgz#7c958514db6ac2443a8abc062dc9f7886a7f6005"
@@ -6665,6 +6687,16 @@ sumchecker@^1.2.0:
   dependencies:
     debug "^2.2.0"
     es6-promise "^4.0.5"
+
+supertap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supertap/-/supertap-1.0.0.tgz#bd9751c7fafd68c68cf8222a29892206a119fa9e"
+  dependencies:
+    arrify "^1.0.1"
+    indent-string "^3.2.0"
+    js-yaml "^3.10.0"
+    serialize-error "^2.1.0"
+    strip-ansi "^4.0.0"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -7268,9 +7300,9 @@ webpack-dev-middleware@1.12.2:
     range-parser "^1.0.3"
     time-stamp "^2.0.0"
 
-webpack-dev-server@^2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-2.10.0.tgz#6db9c77c8cf2e2d7ff85c89fb5e4de6f7227be19"
+webpack-dev-server@^2.11.2:
+  version "2.11.2"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-2.11.2.tgz#1f4f4c78bf1895378f376815910812daf79a216f"
   dependencies:
     ansi-html "0.0.7"
     array-includes "^3.0.3"
@@ -7295,10 +7327,10 @@ webpack-dev-server@^2.10.0:
     sockjs "0.3.19"
     sockjs-client "1.1.4"
     spdy "^3.4.1"
-    strip-ansi "^4.0.0"
+    strip-ansi "^3.0.0"
     supports-color "^5.1.0"
     webpack-dev-middleware "1.12.2"
-    yargs "^10.0.3"
+    yargs "6.6.0"
 
 webpack-sources@^1.0.1:
   version "1.0.1"
@@ -7505,34 +7537,35 @@ yargs-parser@^2.4.1:
     camelcase "^3.0.0"
     lodash.assign "^4.0.6"
 
+yargs-parser@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-4.2.1.tgz#29cceac0dc4f03c6c87b4a9f217dd18c9f74871c"
+  dependencies:
+    camelcase "^3.0.0"
+
 yargs-parser@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
   dependencies:
     camelcase "^4.1.0"
 
-yargs-parser@^8.1.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
+yargs@6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-6.6.0.tgz#782ec21ef403345f830a808ca3d513af56065208"
   dependencies:
-    camelcase "^4.1.0"
-
-yargs@^10.0.3:
-  version "10.1.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.1.1.tgz#5fe1ea306985a099b33492001fa19a1e61efe285"
-  dependencies:
-    cliui "^4.0.0"
+    camelcase "^3.0.0"
+    cliui "^3.2.0"
     decamelize "^1.1.1"
-    find-up "^2.1.0"
     get-caller-file "^1.0.1"
-    os-locale "^2.0.0"
+    os-locale "^1.4.0"
+    read-pkg-up "^1.0.1"
     require-directory "^2.1.1"
     require-main-filename "^1.0.1"
     set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
+    string-width "^1.0.2"
+    which-module "^1.0.0"
     y18n "^3.2.1"
-    yargs-parser "^8.1.0"
+    yargs-parser "^4.2.0"
 
 yargs@^4.2.0:
   version "4.8.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7236,9 +7236,9 @@ vue-template-es2015-compiler@^1.2.2, vue-template-es2015-compiler@^1.5.0:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.5.3.tgz#22787de4e37ebd9339b74223bc467d1adee30545"
 
-vue-thin-modal@^0.2.5:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/vue-thin-modal/-/vue-thin-modal-0.2.5.tgz#62102d1d58683a06a3f739840396112cc34d9037"
+vue-thin-modal@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/vue-thin-modal/-/vue-thin-modal-0.3.0.tgz#1c8940641746e2e8db08e701df880d408b3db1c5"
 
 vue@^2.3.3:
   version "2.4.2"


### PR DESCRIPTION
While showing screenshot images on modal is a great choice to see its detail or compare them by the users' eye, I've encountered some problems.

1. The modal content can't be scrolled when the image is very large.
2. The background content scroll position flickers when the modal open/close.

The first problem is because there are overlapping element over the modal to handle the user interaction. I guess it was there because you want to close the modal wherever the user clicks on the modal. But it looks can be achieved by setting `pointer-events: none;` on the modal content and it's already there. So I just removed it.

The second problem is because the `modal-open` class is added to `<html>` by `vue-thin-modal` (Thanks for using it, BTW!). It does not cause the problem when the `<html>` element is the browser default, but as the report page has a style `height: 100%` on `<html>`, it resets scroll position unintentionally. I just published v0.3.0 of `vue-thin-modal` which fixes this problem (applying `modal-open` to `<body>` instead).

I also changed the version of `webpack-dev-server` to v2 because its v3 does not seem to be compatible with webpack v3 (and coundn't debug the report page without changing it).

BTW, thanks for making the great tool 👍  It really helps my projects' workflow easier!