### PR TITLE
fix: fix bug with update flag (#136)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "chalk": "^2.3.0",
     "cli-spinner": "^0.2.7",
     "cross-spawn": "^5.1.0",
+    "del": "^3.0.0",
     "glob": "^7.1.2",
     "img-diff-js": "^0.4.0",
     "lodash": "^4.17.4",


### PR DESCRIPTION
This fixes https://github.com/reg-viz/reg-cli/issues/136.

It also helps to avoid unnecessary updates to the `expected` images. Without this change, `--update` will touch all the files in the `expected` directory – even when it's not necessary to make tests pass (which bloats commits with unnecessary image changes).

With this change, `--update` only removes images which have been deleted or modified, and it only adds images which have been added or modified.