### PR TITLE
Add a command line argument to control pixelmatch's threshold option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ $ reg-cli /path/to/actual-dir /path/to/expected-dir /path/to/diff-dir -R ./repor
   * `-J`, `--json` Specified json report path. If omitted `./reg.json`
   * `-I`, `--ignoreChange` If true, error will not be thrown when image change detected.
   * `-P`, `--urlPrefix` Add prefix to all image src.
-  * `-T`, `--thresholdRate` Rate threshold for detecting change. When the difference ratio of the image is larger than the set rate detects the change.
-  * `-S`, `--thresholdPixel` Pixel threshold for detecting change. When the difference pixel of the image is larger than the set pixel detects the change. This value takes precedence over `thresholdRate`.
+  * `-M`, `--matchingThreshold` Matching threshold, ranges from 0 to 1. Smaller values make the comparison more sensitive. 0 by default.
+  * `-T`, `--thresholdRate` Rate threshold for detecting change. When the difference ratio of the image is larger than the set rate detects the change. Applied after `matchingbhreshold`.
+  * `-S`, `--thresholdPixel` Pixel threshold for detecting change. When the difference pixel of the image is larger than the set pixel detects the change. This value takes precedence over `thresholdRate`. Applied after `matchingThreshold`.
   * `-C`, `--concurrency` How many processes launches in parallel. If omitted 4.
   * `-A`, `--enableAntialias` Enable antialias. If omitted false.
   * `-X`, `--additionalDetection`. Enable additional difference detection(highly experimental). Select "none" or "client" (default: "none").

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ reg-cli /path/to/actual-dir /path/to/expected-dir /path/to/diff-dir -R ./repor
   * `-I`, `--ignoreChange` If true, error will not be thrown when image change detected.
   * `-P`, `--urlPrefix` Add prefix to all image src.
   * `-M`, `--matchingThreshold` Matching threshold, ranges from 0 to 1. Smaller values make the comparison more sensitive. 0 by default.
-  * `-T`, `--thresholdRate` Rate threshold for detecting change. When the difference ratio of the image is larger than the set rate detects the change. Applied after `matchingbhreshold`.
+  * `-T`, `--thresholdRate` Rate threshold for detecting change. When the difference ratio of the image is larger than the set rate detects the change. Applied after `matchingThreshold`.
   * `-S`, `--thresholdPixel` Pixel threshold for detecting change. When the difference pixel of the image is larger than the set pixel detects the change. This value takes precedence over `thresholdRate`. Applied after `matchingThreshold`.
   * `-C`, `--concurrency` How many processes launches in parallel. If omitted 4.
   * `-A`, `--enableAntialias` Enable antialias. If omitted false.

--- a/src/cli.js
+++ b/src/cli.js
@@ -30,6 +30,7 @@ const cli = meow(`
     -I, --ignoreChange If true, error will not be thrown when image change detected.
     -R, --report Output html report to specified directory.
     -P, --urlPrefix Add prefix to all image src.
+    -M, --matchingThreshold Matching threshold, ranges from 0 to 1. Smaller values make the comparison more sensitive. 0 by default.
     -T, --thresholdRate Rate threshold for detecting change. When the difference ratio of the image is larger than the set rate detects the change.
     -S, --thresholdPixel Pixel threshold for detecting change. When the difference pixel of the image is larger than the set pixel detects the change. This value takes precedence over \`thresholdRate\`.
     -C, --concurrency How many processes launches in parallel. If omitted 4.
@@ -44,6 +45,7 @@ const cli = meow(`
       I: 'ignoreChange',
       R: 'report',
       P: 'urlPrefix',
+      M: 'matchingThreshold',
       T: 'thresholdRate',
       S: 'thresholdPixel',
       C: 'concurrency',
@@ -78,6 +80,7 @@ const observer = compare({
   report,
   json,
   urlPrefix,
+  matchingThreshold: Number(cli.flags.matchingThreshold),
   thresholdRate: Number(cli.flags.thresholdRate),
   thresholdPixel: Number(cli.flags.thresholdPixel),
   concurrency: Number(cli.flags.concurrency) || 4,

--- a/src/diff.js
+++ b/src/diff.js
@@ -9,6 +9,7 @@ export type DiffCreatorParams = {
   expectedDir: string;
   diffDir: string;
   image: string;
+  matchingThreshold: number,
   thresholdRate?: number,
   thresholdPixel?: number,
   enableAntialias: boolean;
@@ -44,7 +45,7 @@ const isPassed = ({ width, height, diffCount, thresholdPixel, thresholdRate }: {
 };
 
 const createDiff = ({
-  actualDir, expectedDir, diffDir, image, thresholdRate, thresholdPixel, enableAntialias
+  actualDir, expectedDir, diffDir, image, matchingThreshold, thresholdRate, thresholdPixel, enableAntialias
 }: DiffCreatorParams) => {
   return Promise.all([
     getMD5(path.join(actualDir, image)),
@@ -60,7 +61,7 @@ const createDiff = ({
       expectedFilename: path.join(expectedDir, image),
       diffFilename: path.join(diffDir, diffImage),
       options: {
-        threshold: 0,
+        threshold: matchingThreshold,
         includeAA: !enableAntialias,
       },
     })

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ type RegParams = {
   json?: string,
   update?: boolean,
   urlPrefix?: string,
+  matchingThreshold?: number,
   threshold?: number, // alias to thresholdRate.
   thresholdRate?: number,
   thresholdPixel?: number,
@@ -62,7 +63,7 @@ const copyImages = (actualImages, { expectedDir, actualDir }) => {
 
 const compareImages = (
   emitter,
-  { expectedImages, actualImages, dirs, thresholdPixel, thresholdRate, concurrency, enableAntialias },
+  { expectedImages, actualImages, dirs, matchingThreshold, thresholdPixel, thresholdRate, concurrency, enableAntialias },
 ): Promise<CompareResult[]> => {
   const images = actualImages.filter(actualImage => expectedImages.includes(actualImage));
   concurrency = images.length < 20 ? 1 : concurrency || 4;
@@ -76,6 +77,7 @@ const compareImages = (
           return p.run({
             ...dirs,
             image,
+            matchingThreshold,
             thresholdRate,
             thresholdPixel,
             enableAntialias,
@@ -125,6 +127,7 @@ module.exports = (params: RegParams) => {
     report,
     urlPrefix,
     threshold,
+    matchingThreshold,
     thresholdRate,
     thresholdPixel,
     enableAntialias,
@@ -144,6 +147,7 @@ module.exports = (params: RegParams) => {
     expectedImages,
     actualImages,
     dirs,
+    matchingThreshold,
     thresholdRate: thresholdRate || threshold,
     thresholdPixel,
     concurrency,


### PR DESCRIPTION
Fixes #203 