### PR TITLE
fix: modify image path working with windows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -135,8 +135,8 @@ module.exports = (params: RegParams) => {
   } = params;
   const dirs = { actualDir, expectedDir, diffDir };
   const emitter = new EventEmitter();
-  const expectedImages = glob.sync(`${expectedDir}${IMAGE_FILES}`).map(path => path.replace(expectedDir, '')).map(p => p[0] === path.sep ? p.slice(1) : p);
-  const actualImages = glob.sync(`${actualDir}${IMAGE_FILES}`).map(path => path.replace(actualDir, '')).map(p => p[0] === path.sep ? p.slice(1) : p);
+  const expectedImages = glob.sync(`${expectedDir}${IMAGE_FILES}`).map(p => path.relative(expectedDir, p)).map(p => p[0] === path.sep ? p.slice(1) : p);
+  const actualImages = glob.sync(`${actualDir}${IMAGE_FILES}`).map(p => path.relative(actualDir, p)).map(p => p[0] === path.sep ? p.slice(1) : p);
   const deletedImages = difference(expectedImages, actualImages);
   const newImages = difference(actualImages, expectedImages);
   mkdirp.sync(expectedDir);


### PR DESCRIPTION
When running on Windows, node glob returns paths like `C:/path/to/workspace/.reg/actual/Default.png` while `actualDir`(and `expectedDir`) is like `C:\path\to\workspace\.reg\actual`.

As a result, the `expectedImages` and `actualImages` remain to be absolute.

To fix them, changed the way to make paths relative.