### PR TITLE
Fix UI build scripts

### DIFF
--- a/scripts/build-ui.sh
+++ b/scripts/build-ui.sh
@@ -1,10 +1,13 @@
 #!/bin/sh
+
 VERSION=$1
 DIR=report/ui
 
+set -eux
+
 if [ -e "$DIR" ]; then
   cd $DIR
-  git fetch origin
+  git fetch origin --tags
   git checkout refs/tags/$VERSION
 else
   git clone https://github.com/reg-viz/reg-cli-report-ui.git -b $VERSION $DIR --depth 1
@@ -16,6 +19,3 @@ yarn install --frozen-lockfile
 yarn build
 
 touch .npmignore
-
-
-


### PR DESCRIPTION
## What does this change?

The currently published version of reg-cli contains an old UI Report. (current: `reg-cli@0.17.1`)

This is because there was a bug in the script used to build the Report UI. If you run `yarn build:report` with the `report/ui` directory already present in `master` branch, you will get the following error:

```bash
error: pathspec 'refs/tags/v0.2.0' did not match any file(s) known to git
```

This error occurred because you did not get the latest Git tag from Origin.

### Notes

I have checked the version of Report UI included in the latest `reg-cli` with the following script:

```bash
$ mkdir foo
$ cd foo
$ npm init -y
$ npm i -D reg-cli
$ cat node_modules/reg-cli/report/ui/package.json | jq .version
"0.1.2"
```

## References

- n/a

## Screenshots

n/a

## What can I check for bug fixes?

```bash
$ yarn build:report
```