### PR TITLE
fix: cli value

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ $ reg-cli /path/to/actual-dir /path/to/expected-dir /path/to/diff-dir -R ./repor
   * `-E`, `--extendedErrors` If true, also added/deleted images will throw an error.
   * `-P`, `--urlPrefix` Add prefix to all image src.
   * `-M`, `--matchingThreshold` Matching threshold, ranges from 0 to 1. Smaller values make the comparison more sensitive. 0 by default.
-  * `-T`, `--thresholdRate` Rate threshold for detecting change. When the difference ratio of the image is larger than the set rate detects the change. Applied after `matchingThreshold`.
-  * `-S`, `--thresholdPixel` Pixel threshold for detecting change. When the difference pixel of the image is larger than the set pixel detects the change. This value takes precedence over `thresholdRate`. Applied after `matchingThreshold`.
+  * `-T`, `--thresholdRate` Rate threshold for detecting change. When the difference ratio of the image is larger than the set rate detects the change. Applied after `matchingThreshold`. 0 by default.
+  * `-S`, `--thresholdPixel` Pixel threshold for detecting change. When the difference pixel of the image is larger than the set pixel detects the change. This value takes precedence over `thresholdRate`. Applied after `matchingThreshold`. 0 by default.
   * `-C`, `--concurrency` How many processes launches in parallel. If omitted 4.
   * `-A`, `--enableAntialias` Enable antialias. If omitted false.
   * `-X`, `--additionalDetection`. Enable additional difference detection(highly experimental). Select "none" or "client" (default: "none").

--- a/src/cli.js
+++ b/src/cli.js
@@ -115,10 +115,10 @@ const observer = compare({
   report,
   json,
   urlPrefix,
-  matchingThreshold: Number(cli.flags.matchingThreshold),
+  matchingThreshold: Number(cli.flags.matchingThreshold || 0),
   thresholdRate: Number(cli.flags.thresholdRate),
   thresholdPixel: Number(cli.flags.thresholdPixel),
-  concurrency: Number(cli.flags.concurrency) || 4,
+  concurrency: Number(cli.flags.concurrency || 4),
   enableAntialias: !!cli.flags.enableAntialias,
   enableClientAdditionalDetection,
 });


### PR DESCRIPTION
## What does this change?

Fixed a cli flags input bug.
if you omit matchingThreathold option, it is treated as 0.1.

## References

NA

## Screenshots

NA

## What can I check for bug fixes?

NA
