### PR TITLE
Narrow WASI sandbox: single-ancestor preopen + env allowlist

### DIFF
--- a/js/entry.ts
+++ b/js/entry.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import { WASI, type IFs } from '@tybys/wasm-util';
 import { env } from 'node:process';
 import { parentPort, workerData } from 'node:worker_threads';
-import { readWasm } from './utils';
+import { computeWasiSandbox, readWasm } from './utils';
 import { type RustTraceData, type WorkerSpan } from './tracing';
 
 // Check if tracing is enabled via environment variable
@@ -43,12 +43,16 @@ export type CompareOutput = {
   diffDir: string;
 };
 
+// Build the narrowest WASI sandbox this run needs. See `computeWasiSandbox`
+// in utils.ts for the policy.
+const sandbox = computeWasiSandbox(workerData.argv);
+
 const wasi = new WASI({
   version: 'preview1',
   args: workerData.argv,
-  env: env as Record<string, string>,
+  env: sandbox.env,
   returnOnExit: true,
-  preopens: { './': './' },
+  preopens: sandbox.preopens,
   fs: fs as IFs,
 });
 

--- a/js/utils.ts
+++ b/js/utils.ts
@@ -1,7 +1,8 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { dirname, join, resolve as pathResolve } from 'node:path';
+import { env as procEnv, cwd as procCwd } from 'node:process';
 
 export const isCJS = typeof __dirname !== 'undefined';
 
@@ -13,4 +14,146 @@ export const readWasm = () => {
 
 export const resolveExtention = (): string => {
   return isCJS ? 'cjs' : 'mjs';
+};
+
+/**
+ * Host environment variables intentionally forwarded into the Wasm sandbox.
+ * Everything else (shell secrets, CI credentials, AWS_*, NPM_TOKEN, ...) is
+ * filtered out.
+ */
+const FORWARDED_ENV = [
+  'OTEL_ENABLED',
+  'JAEGER_ENABLED',
+  'OTEL_DEBUG',
+  'OTEL_EXPORTER_OTLP_ENDPOINT',
+  'OTEL_EXPORTER_OTLP_PROTOCOL',
+  'OTEL_SERVICE_NAME',
+  'OTEL_TRACES_EXPORTER',
+  'OTEL_RESOURCE_ATTRIBUTES',
+] as const;
+
+/**
+ * Longest directory path that every input in `paths` lives under. Treats
+ * each path as a sequence of "/"-separated segments; absolute-vs-relative
+ * mixes fall back to '.'.
+ */
+const commonAncestor = (paths: string[]): string => {
+  const defined = paths.filter(Boolean);
+  if (defined.length === 0) return '.';
+  if (defined.length === 1) return defined[0];
+  // If absolute and relative are mixed we can't compute a meaningful common
+  // ancestor without risking opening "/". Bail to CWD.
+  const isAbs = (p: string) => p.startsWith('/');
+  const anyAbs = defined.some(isAbs);
+  const allAbs = defined.every(isAbs);
+  if (anyAbs && !allAbs) return '.';
+  const split = defined.map((p) => p.split('/').filter(Boolean));
+  const shortest = Math.min(...split.map((s) => s.length));
+  const common: string[] = [];
+  for (let i = 0; i < shortest; i++) {
+    const seg = split[0][i];
+    if (split.every((s) => s[i] === seg)) common.push(seg);
+    else break;
+  }
+  if (common.length === 0) return allAbs ? '/' : '.';
+  return (allAbs ? '/' : '') + common.join('/');
+};
+
+export type WasiSandbox = {
+  /** Directories mapped into the Wasm sandbox. Everything else is invisible. */
+  preopens: Record<string, string>;
+  /** Allowlist-filtered environment variables. */
+  env: Record<string, string>;
+};
+
+/**
+ * Compute the minimum-capability WASI sandbox for a given reg-cli invocation:
+ *
+ *   - preopen only the smallest ancestor directory that covers every path
+ *     this run touches (actualDir, expectedDir, diffDir, and the parents
+ *     of --report / --json)
+ *   - forward only an allowlisted subset of host env into Wasm
+ *
+ * Before this, entry.ts / worker.ts did `preopens: { './': './' }` which
+ * exposed the entire cwd (and therefore `.npmrc`, `.env`, `node_modules`,
+ * etc.) to whatever runs inside Wasm. Narrowing matters because reg-cli
+ * deliberately ingests untrusted images from CI and image decoders
+ * (libpng, libwebp, libjpeg) have a long history of RCE-class CVEs.
+ *
+ * Why a single common-ancestor and not one preopen per directory:
+ *   On the `wasm32-wasip1-threads` target, Rust's libstd only enumerates
+ *   the first preopen returned by WASI (`fd_prestat_get(3)` is queried but
+ *   `fd_prestat_get(4)` is never issued). Until that's fixed upstream,
+ *   registering one preopen per dir effectively hides every dir but the
+ *   first. Picking the narrowest *single* ancestor that still contains
+ *   every touched path gives us a real-world win without tripping the bug.
+ *
+ * Caveats (follow-ups, not in this PR):
+ *   - Symlinks and FIFOs inside the preopened directory are still resolved
+ *     by the host, so an attacker who can plant files under `./diff/` could
+ *     still exfiltrate via an evil symlink pointing outside the sandbox.
+ *     Addressing this needs host-side WASI changes.
+ *   - `@tybys/wasm-util`'s WASI still runs on top of Node's `fs` with full
+ *     privilege (`fs: fs as IFs`); we only constrain *what paths Wasm is
+ *     allowed to name*, not what the host fs underneath could do.
+ *   - One-preopen-per-dir limitation above.
+ */
+export const computeWasiSandbox = (argv: string[]): WasiSandbox => {
+  // run() in index.ts wraps argv with a leading "--" sentinel before passing
+  // it through WASI. Strip that so we see the user's original args.
+  const args = argv[0] === '--' ? argv.slice(1) : argv;
+
+  // Positional args (up to 3) = actualDir, expectedDir, diffDir.
+  const positional: string[] = [];
+  for (let i = 0; i < args.length && positional.length < 3; i++) {
+    if (args[i].startsWith('--')) break;
+    positional.push(args[i]);
+  }
+
+  const flagValue = (name: string): string | undefined => {
+    const i = args.indexOf(name);
+    return i >= 0 && i + 1 < args.length ? args[i + 1] : undefined;
+  };
+
+  const dirs: string[] = [];
+  for (const p of positional) if (p) dirs.push(p);
+  const report = flagValue('--report');
+  const json = flagValue('--json');
+  if (report) dirs.push(dirname(report) || '.');
+  if (json) dirs.push(dirname(json) || '.');
+
+  // Collapse every requested directory into a single shared ancestor.
+  //
+  // We originally tried to register 3-5 individual preopens (actual / expected
+  // / diff / report / json). Problem: `wasm32-wasip1-threads` libstd's
+  // preopen-enumeration appears to stop enumerating after fd 3 (only the
+  // first preopen is actually visible to the Rust side), so only one preopen
+  // becomes usable per run. Until that is fixed upstream, fall back to the
+  // narrowest *single* directory that contains every path this run touches.
+  //
+  // That's still a large improvement over `{'./': './'}`: on a typical
+  // invocation (`reg-cli <repo>/actual <repo>/expected <repo>/diff ...`) the
+  // preopen becomes `<repo>` rather than the entire CWD.
+  const preopenRoot = commonAncestor(dirs) || '.';
+  const mapWasm = (p: string): string =>
+    p === '.' || p === './' || p.startsWith('/') || p.startsWith('./')
+      ? p
+      : `./${p}`;
+  const preopens: Record<string, string> = {
+    [mapWasm(preopenRoot)]: preopenRoot,
+  };
+
+  // Fallback: if argv doesn't carry any dirs (--help, --version), let the
+  // binary still render to stderr by preopening the current directory.
+  if (!preopenRoot || preopenRoot === '.' || preopenRoot === './') {
+    preopens['./'] = './';
+  }
+
+  const env: Record<string, string> = {};
+  for (const k of FORWARDED_ENV) {
+    const v = procEnv[k];
+    if (v !== undefined) env[k] = v;
+  }
+
+  return { preopens, env };
 };

--- a/js/worker.ts
+++ b/js/worker.ts
@@ -2,7 +2,7 @@ import { parentPort, workerData } from 'node:worker_threads';
 import fs from 'node:fs';
 import { WASI, type IFs } from '@tybys/wasm-util';
 import { argv, env } from 'node:process';
-import { readWasm, resolveExtention } from './utils';
+import { computeWasiSandbox, readWasm, resolveExtention } from './utils';
 // https://github.com/toyobayashi/emnapi/blob/5ab92c706c7cd4a0a30759e58f26eedfb0ded591/packages/wasi-threads/src/wasi-threads.ts#L288-L335
 import { createInstanceProxy } from './proxy';
 import { type WorkerSpan } from './tracing';
@@ -10,13 +10,17 @@ import { type WorkerSpan } from './tracing';
 const isTracingEnabled = (): boolean =>
   env.OTEL_ENABLED === 'true' || env.JAEGER_ENABLED === 'true';
 
+// Each rayon worker thread (Node Worker) has its own WASI instance and fd
+// table, so we must narrow its sandbox too — not just the main entry one.
+const sandbox = computeWasiSandbox(workerData.argv);
+
 // Per-handler buffer. Sent to parent on completion.
 const wasi = new WASI({
   version: 'preview1',
   args: workerData.argv,
-  env: env as Record<string, string>,
+  env: sandbox.env,
   returnOnExit: true,
-  preopens: { './': './' },
+  preopens: sandbox.preopens,
   fs: fs as IFs,
 });
 


### PR DESCRIPTION
## Summary

- **Narrow the WASI `preopens`** from the full cwd (`{ './': './' }`) to the single smallest ancestor directory that still contains every path this run touches (actual, expected, diff, + parents of `--report` / `--json`).
- **Allowlist-filter `env`**: forward only OTel-related variables into Wasm. Everything else (`AWS_*`, `NPM_TOKEN`, CI secrets, ...) stops at the host boundary.

Before this, a hypothetical image-decoder RCE inside Wasm could read anything under the cwd (`.npmrc`, `.env`, `node_modules`, ...) and see every host env var. After this, the surface shrinks to "the fixture folder this specific invocation needs" and "a handful of OTel variables".

## Why only one ancestor preopen?

The ideal is one preopen per logical directory (actual, expected, diff, …). I tried that first — but on `wasm32-wasip1-threads`, Rust's libstd only queries `fd_prestat_get(3)` and never enumerates fd 4+, so every preopen but the first becomes invisible to Rust. All the correctly-registered WASI-side preopens are ignored.

Until that's fixed upstream, collapsing to a single common ancestor gives us the practical win without triggering the bug. Typical before/after on a project:

```
before:  preopens = { './': '<repo root>' }
after:   preopens = { './fixtures': '<repo>/fixtures' }
```

## What this does NOT do (explicit follow-ups)

- **Symlinks / FIFOs inside the preopen** are still resolved by the host. An attacker who can write `./diff/leak -> /tmp/pipe` still has an exfiltration path via the diff directory. Needs host-side WASI changes (reject non-regular files).
- **`fs: fs as IFs` still hands `@tybys/wasm-util` unrestricted Node `fs`.** We're only constraining *which paths Wasm is allowed to name*, not what the host fs layer could do on Wasm's behalf.
- **stdout / stderr inheritance**: if the host redirects them to a socket (`reg-cli > >(nc ...)`) Wasm output leaves the box through the host pipe, not a WASI call. That's a host-configuration concern.

## Other change in this PR

Bumps `rust-toolchain.toml` from `nightly-2024-08-24` → `nightly-2025-01-01`. Required because a transitive dep now needs `edition2024`. No behavioural change otherwise.

## Test plan

- [x] 20 images × 1280×720 fixture: same output as before (16 diff images, report.html, identical reg.json contents)
- [x] 100 images × 1280×720: same
- [x] `SECRET_TOKEN=leak NPM_TOKEN=leak AWS_ACCESS_KEY_ID=leak reg-cli ...` — confirmed those envs are NOT forwarded (`sandbox.env` keys are `["OTEL_ENABLED"]` only, verified via temporary logging during bring-up)
- [x] `--help` / `--version` still work (fallback to `./` preopen when no fixture args present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)