### PR TITLE
CLI compat (phase A): exit codes, short aliases, -I / -E / -U, error event

### DIFF
--- a/crates/reg_cli/src/main.rs
+++ b/crates/reg_cli/src/main.rs
@@ -30,33 +30,32 @@ struct Args {
     #[clap(index = 3)]
     diff_dir: PathBuf,
 
-    #[arg(long)]
+    #[arg(short = 'R', long)]
     report: Option<PathBuf>,
 
-    #[arg(long)]
+    #[arg(short = 'J', long)]
     json: Option<PathBuf>,
 
-    #[arg(long = "matchingThreshold")]
+    #[arg(short = 'M', long = "matchingThreshold")]
     matching_threshold: Option<f32>,
 
-    #[arg(long = "thresholdRate")]
+    #[arg(short = 'T', long = "thresholdRate")]
     threshold_rate: Option<f32>,
 
-    #[arg(long = "thresholdPixel")]
+    #[arg(short = 'S', long = "thresholdPixel")]
     threshold_pixel: Option<u64>,
 
-    #[arg(long = "urlPrefix")]
+    #[arg(short = 'P', long = "urlPrefix")]
     url_prefix: Option<Url>,
 
-    #[arg(long)]
+    #[arg(short = 'C', long)]
     concurrency: Option<usize>,
 
-    #[arg(long = "enableAntialias")]
+    #[arg(short = 'A', long = "enableAntialias", default_missing_value = "true", num_args = 0..=1)]
     enable_antialias: Option<bool>,
 
     /// Output format for diff images. `webp` (default) matches the current
-    /// Rust/Wasm behaviour. `png` matches the classic JS implementation and
-    /// is useful for apples-to-apples benchmarking.
+    /// Rust/Wasm behaviour. `png` matches the classic JS implementation.
     #[arg(long = "diffFormat", value_enum)]
     diff_format: Option<DiffFormatArg>,
 }

--- a/js/cli.ts
+++ b/js/cli.ts
@@ -1,6 +1,186 @@
-import { run } from './';
+#!/usr/bin/env node
+//
+// CLI wrapper around the Wasm `run()` entry point.
+//
+// Goal: match the surface of classic reg-cli (`src/cli.js`) closely enough
+// that users migrating from `reg-cli` to `@bokuweb/reg-cli-wasm` do not have
+// to change their CI invocation. Specifically this handles:
+//
+//   - POSIX short-flag aliases (-R, -J, -M, -T, -S, -C, -A, -I, -E, -U, -D)
+//   - Non-zero exit code on pixel diff (`process.exitCode = 1`)
+//   - Per-file progress log + summary line
+//   - `-U / --update` baseline refresh
+//   - `-I / --ignoreChange` overrides the non-zero exit code
+//   - `-E / --extendedErrors` escalates new/deleted counts to failure
+//   - `-D / --customDiffMessage` custom trailer line
+//
+// Still handled in the Wasm (Rust) side via clap short aliases:
+//
+//   -R/--report, -J/--json, -M/--matchingThreshold, -T/--thresholdRate,
+//   -S/--thresholdPixel, -P/--urlPrefix, -C/--concurrency, -A/--enableAntialias,
+//   --diffFormat
+//
+// Not yet supported (follow-up PR):
+//   -F/--from, --junit, -X/--additionalDetection
+//
+import { parseArgs } from 'node:util';
+import { copyFile, mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { run, type CompareOutput } from './';
 
-// WASI expects argv[0] to be the program name, use '--' as placeholder
-const emitter = run(['--', ...process.argv.slice(2)]);
+const HELP = `
+  Usage
+    $ reg-cli /path/to/actual-dir /path/to/expected-dir /path/to/diff-dir
+  Options
+    -U, --update              Update expected images (copy actual → expected).
+    -R, --report              Output html report to specified path.
+    -J, --json                Output json report to specified path (default ./reg.json).
+    -I, --ignoreChange        Exit 0 even when image changes are detected.
+    -E, --extendedErrors      Also treat added/deleted images as failures.
+    -P, --urlPrefix           Prefix for image src in html report.
+    -M, --matchingThreshold   YIQ threshold (0-1). Default 0.
+    -T, --thresholdRate       Ratio of pixels that may differ before failing.
+    -S, --thresholdPixel      Absolute pixel count that may differ before failing.
+    -C, --concurrency         Parallel worker count. Default 4.
+    -A, --enableAntialias     Count anti-aliased pixels as different.
+    -D, --customDiffMessage   Trailing message printed on diff.
+        --diffFormat          webp (default) | png
+`;
 
-emitter.on('complete', data => {});
+if (process.argv.includes('-h') || process.argv.includes('--help')) {
+  process.stdout.write(HELP);
+  process.exit(0);
+}
+if (process.argv.includes('--version')) {
+  // Keep in sync with package.json via build if we care; fine as a placeholder.
+  process.stdout.write('reg-cli-wasm\n');
+  process.exit(0);
+}
+
+let parsed;
+try {
+  parsed = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      update: { type: 'boolean', short: 'U' },
+      json: { type: 'string', short: 'J' },
+      ignoreChange: { type: 'boolean', short: 'I' },
+      extendedErrors: { type: 'boolean', short: 'E' },
+      report: { type: 'string', short: 'R' },
+      urlPrefix: { type: 'string', short: 'P' },
+      matchingThreshold: { type: 'string', short: 'M' },
+      thresholdRate: { type: 'string', short: 'T' },
+      thresholdPixel: { type: 'string', short: 'S' },
+      concurrency: { type: 'string', short: 'C' },
+      enableAntialias: { type: 'boolean', short: 'A' },
+      customDiffMessage: { type: 'string', short: 'D' },
+      diffFormat: { type: 'string' },
+    },
+    allowPositionals: true,
+  });
+} catch (err) {
+  process.stderr.write(`reg-cli: ${(err as Error).message}\n`);
+  process.stderr.write(HELP);
+  process.exit(1);
+}
+
+const { values, positionals } = parsed;
+const [actualDir, expectedDir, diffDir] = positionals;
+
+if (!actualDir || !expectedDir || !diffDir) {
+  process.stderr.write('reg-cli: please specify actual, expected and diff directories.\n');
+  process.stderr.write(HELP);
+  process.exit(1);
+}
+
+// CLI-only semantics (not forwarded to Wasm).
+const update = !!values.update;
+const ignoreChange = !!values.ignoreChange;
+const extendedErrors = !!values.extendedErrors;
+const customDiffMessage =
+  typeof values.customDiffMessage === 'string'
+    ? values.customDiffMessage
+    : `\nInspect your code changes, re-run with \`-U\` to update them. `;
+
+// Forward to Wasm: only flags that Rust/clap understands.
+const wasmArgv: string[] = ['--', actualDir, expectedDir, diffDir];
+const pushFlag = (name: string, v: unknown): void => {
+  if (v == null || v === false) return;
+  if (v === true) wasmArgv.push(`--${name}`);
+  else wasmArgv.push(`--${name}`, String(v));
+};
+pushFlag('report', values.report);
+pushFlag('json', values.json);
+pushFlag('matchingThreshold', values.matchingThreshold);
+pushFlag('thresholdRate', values.thresholdRate);
+pushFlag('thresholdPixel', values.thresholdPixel);
+pushFlag('urlPrefix', values.urlPrefix);
+pushFlag('concurrency', values.concurrency);
+pushFlag('enableAntialias', values.enableAntialias);
+pushFlag('diffFormat', values.diffFormat);
+
+const CHECK = '\u2714'; // ✔
+const CROSS = '\u2718'; // ✘
+const PLUS = '\u271A'; // ✚
+const MINUS = '\u2212'; // −
+
+const formatPath = (p: string) => join(actualDir, p);
+
+const emitter = run(wasmArgv);
+
+emitter.once('complete', async (data: CompareOutput) => {
+  const failed = data.failedItems ?? [];
+  const passed = data.passedItems ?? [];
+  const added = data.newItems ?? [];
+  const deleted = data.deletedItems ?? [];
+
+  // Per-file lines (ordering roughly follows classic reg-cli).
+  for (const img of passed) process.stdout.write(`${CHECK} pass    ${formatPath(img)}\n`);
+  for (const img of added) process.stdout.write(`${PLUS} append  ${formatPath(img)}\n`);
+  for (const img of deleted) process.stdout.write(`${MINUS} delete  ${formatPath(img)}\n`);
+  for (const img of failed) process.stdout.write(`${CROSS} change  ${formatPath(img)}\n`);
+
+  // Summary lines.
+  process.stdout.write('\n');
+  if (failed.length) process.stdout.write(`${CROSS} ${failed.length} file(s) changed.\n`);
+  if (deleted.length) process.stdout.write(`${MINUS} ${deleted.length} file(s) deleted.\n`);
+  if (added.length) process.stdout.write(`${PLUS} ${added.length} file(s) appended.\n`);
+  if (passed.length) process.stdout.write(`${CHECK} ${passed.length} file(s) passed.\n`);
+
+  if (update) {
+    try {
+      await updateExpected(actualDir, expectedDir, data.actualItems ?? []);
+      process.stdout.write('\u2728 your expected images are updated \u2728\n');
+    } catch (e) {
+      process.stderr.write(`reg-cli: failed to update expected — ${(e as Error).message}\n`);
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  const hasFailure =
+    failed.length > 0 || (extendedErrors && (added.length > 0 || deleted.length > 0));
+
+  if (hasFailure) {
+    process.stdout.write(`${customDiffMessage}\n`);
+    if (!ignoreChange) process.exitCode = 1;
+  }
+});
+
+emitter.once('error', (err: Error) => {
+  process.stderr.write(`reg-cli: ${err?.message ?? String(err)}\n`);
+  process.exitCode = 1;
+});
+
+async function updateExpected(
+  actualDir: string,
+  expectedDir: string,
+  images: string[],
+): Promise<void> {
+  for (const img of images) {
+    const src = join(actualDir, img);
+    const dst = join(expectedDir, img);
+    await mkdir(dirname(dst), { recursive: true });
+    await copyFile(src, dst);
+  }
+}

--- a/js/index.ts
+++ b/js/index.ts
@@ -75,7 +75,10 @@ export const run = (argv: string[]): EventEmitter => {
 
     worker.on('error', (e: Error) => {
       workers.forEach((w) => w.terminate());
-      throw new Error(e.message);
+      // Forward as an `error` event on the parent emitter so callers can
+      // `emitter.on('error', ...)` instead of wrapping in a global handler.
+      // (Parity with classic reg-cli's EventEmitter surface.)
+      emitter.emit('error', e);
     });
 
     if (threadId) {
@@ -141,7 +144,7 @@ export const run = (argv: string[]): EventEmitter => {
       endRootSpan(false);
     }
     workers.forEach((w) => w.terminate());
-    throw new Error(err.message);
+    emitter.emit('error', err);
   });
 
   return emitter;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-08-24"
+channel = "nightly-2025-01-01"
 targets = ["wasm32-wasip1-threads"]


### PR DESCRIPTION
## Why

`@bokuweb/reg-cli-wasm` is supposed to become a drop-in replacement for `reg-cli`, but today it isn't — swapping one for the other breaks CI for the three biggest reasons:

1. **Exit code** — the Wasm CLI always exits 0, so CI never sees a pixel-diff failure.
2. **Short flag aliases** — `-J`, `-R`, `-M`, `-T`, `-S`, `-C`, `-A` all fail with "unexpected argument"; only the long forms work.
3. **Missing CLI semantics** — `-U` (update expected), `-I` (ignoreChange), `-E` (extendedErrors), `-D` (customDiffMessage) are not recognised at all, and there's no progress / summary on stdout.

This PR closes those three first-tier gaps. `--from`, `--junit`, `-X`, and the per-file library events will follow in a separate PR.

## Changes

### Rust / clap (`crates/reg_cli/src/main.rs`)

Adds POSIX short aliases to every existing option:

| short | long | same as classic |
|---|---|---|
| `-R` | `--report` | ✓ |
| `-J` | `--json` | ✓ |
| `-M` | `--matchingThreshold` | ✓ |
| `-T` | `--thresholdRate` | ✓ |
| `-S` | `--thresholdPixel` | ✓ |
| `-P` | `--urlPrefix` | ✓ |
| `-C` | `--concurrency` | ✓ |
| `-A` | `--enableAntialias` | ✓ (now also accepts bare form via `num_args = 0..=1`) |

### CLI wrapper (`js/cli.ts`)

Rewritten as a thin front-end around `run()`. Uses Node's built-in `util.parseArgs` (no new deps).

Now handles:

- `-U / --update` — after the Wasm run completes, copy `actualItems` over `expectedDir` with `mkdir(recursive)` + `copyFile`.
- `-I / --ignoreChange` — suppress the non-zero exit.
- `-E / --extendedErrors` — treat new/deleted counts as failures.
- `-D / --customDiffMessage` — trailing line printed on diff, defaulting to classic's `"Inspect your code changes, re-run with '-U' to update them."`.
- Per-file progress: `✔ pass / ✘ change / ✚ append / − delete` lines, then a summary: `N file(s) changed.`, `N file(s) passed.`, etc.
- `process.exitCode = 1` on failure (honouring `-I`).
- `--help / -h` short-circuit.

### Library (`js/index.ts`)

The two `worker.on('error', e => { throw new Error(e.message) })` handlers became `emitter.emit('error', e)`. Library consumers can now subscribe to `'error'` instead of needing a global `uncaughtException` handler — matching classic reg-cli's `EventEmitter` surface.

### Also

`rust-toolchain.toml` nightly-2024-08-24 → 2025-01-01. A transitive dep now requires `edition2024` which the old nightly cannot stabilise.

## Test plan

- [x] `node js/dist/cli.mjs ... -R ... -J ... -M 0.01 -C 4 --diffFormat png` — all short aliases parsed, 16 PNG diffs produced.
- [x] Diff present, no flag → **exit 1** (was 0).
- [x] Diff present + `-I` → **exit 0**.
- [x] No diff + `-E` → exit 0 (escalation not triggered when there's nothing to escalate).
- [x] `-U` after a diff → `expected/` updated to match `actual/`, exit 0.
- [x] `--help` prints usage and exits 0.
- [x] Missing positional args → clear error + exit 1.

## Intentionally not in this PR (follow-up)

- `-F / --from` (JSON → report without running diff)
- `--junit` output
- `-X / --additionalDetection`
- Library `'start'` / `'compare'` (per-file) / `'update'` events — currently only `'complete'` + `'error'`
- Writing `reg.json` / `junit.xml` to disk by default
- Defaulting `--diffFormat` to `png` to fully match classic's output filenames

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>