### PR TITLE
CLI compat (phase B): library events + --junit

### DIFF
--- a/js/cli.ts
+++ b/js/cli.ts
@@ -27,6 +27,7 @@ import { parseArgs } from 'node:util';
 import { copyFile, mkdir } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { run, type CompareOutput } from './';
+import { writeJunit } from './junit';
 
 const HELP = `
   Usage
@@ -44,6 +45,7 @@ const HELP = `
     -C, --concurrency         Parallel worker count. Default 4.
     -A, --enableAntialias     Count anti-aliased pixels as different.
     -D, --customDiffMessage   Trailing message printed on diff.
+        --junit               Path to write a JUnit XML test report.
         --diffFormat          webp (default) | png
 `;
 
@@ -75,6 +77,7 @@ try {
       enableAntialias: { type: 'boolean', short: 'A' },
       customDiffMessage: { type: 'string', short: 'D' },
       diffFormat: { type: 'string' },
+      junit: { type: 'string' },
     },
     allowPositionals: true,
   });
@@ -97,6 +100,7 @@ if (!actualDir || !expectedDir || !diffDir) {
 const update = !!values.update;
 const ignoreChange = !!values.ignoreChange;
 const extendedErrors = !!values.extendedErrors;
+const junitPath = typeof values.junit === 'string' ? values.junit : undefined;
 const customDiffMessage =
   typeof values.customDiffMessage === 'string'
     ? values.customDiffMessage
@@ -146,6 +150,15 @@ emitter.once('complete', async (data: CompareOutput) => {
   if (deleted.length) process.stdout.write(`${MINUS} ${deleted.length} file(s) deleted.\n`);
   if (added.length) process.stdout.write(`${PLUS} ${added.length} file(s) appended.\n`);
   if (passed.length) process.stdout.write(`${CHECK} ${passed.length} file(s) passed.\n`);
+
+  if (junitPath) {
+    try {
+      await writeJunit(junitPath, data);
+    } catch (e) {
+      process.stderr.write(`reg-cli: failed to write junit report — ${(e as Error).message}\n`);
+      process.exitCode = 1;
+    }
+  }
 
   if (update) {
     try {

--- a/js/index.ts
+++ b/js/index.ts
@@ -42,6 +42,10 @@ export const run = (argv: string[]): EventEmitter => {
 
   const emitter = new EventEmitter();
 
+  // Classic reg-cli fires a 'start' event on the next tick of the run so
+  // subscribers (e.g. spinners) can latch on. Mirror that behaviour.
+  setImmediate(() => emitter.emit('start'));
+
   const t_new_entry = Date.now();
   const worker = new Worker(join(dir(), `./entry.${resolveExtention()}`), { workerData: { argv } });
   recordMainSpan('main.new_entry_worker', t_new_entry);
@@ -122,6 +126,23 @@ export const run = (argv: string[]): EventEmitter => {
       }
 
       workers.forEach((w) => w.terminate());
+
+      // Synthesise per-file `compare` events from the final report so that
+      // classic reg-cli subscribers (`emitter.on('compare', ...)`) keep
+      // working. We don't have live per-image timing from the Wasm side
+      // (the diff runs as one batch inside Rust's rayon pool), so fire them
+      // all before `complete`.
+      if (data && typeof data === 'object') {
+        for (const path of data.passedItems ?? [])
+          emitter.emit('compare', { type: 'pass', path });
+        for (const path of data.newItems ?? [])
+          emitter.emit('compare', { type: 'new', path });
+        for (const path of data.deletedItems ?? [])
+          emitter.emit('compare', { type: 'delete', path });
+        for (const path of data.failedItems ?? [])
+          emitter.emit('compare', { type: 'fail', path });
+      }
+
       // Emit complete and ensure we don't exit before traces are sent
       emitter.emit('complete', data);
       return; // Prevent further processing
@@ -182,8 +203,27 @@ export type CompareOutput = {
   diffDir: string,
 };
 
+/** Flags that `compare()` handles itself in JS; they are NOT forwarded to
+ *  the Wasm binary (which doesn't understand them). */
+const CLI_ONLY_KEYS = new Set<keyof CompareInput>([
+  'update',
+  'junitReport',
+  'extendedErrors', // meta for exit codes only — Wasm doesn't care
+]);
+
 export const compare = (input: CompareInput): EventEmitter => {
-  const { actualDir, expectedDir, diffDir, ...rest } = input;
+  const { actualDir, expectedDir, diffDir, threshold, update, junitReport, ...rest } = input;
+
+  // Translate `threshold` → `thresholdRate` (classic's alias).
+  if (threshold != null && rest.thresholdRate == null) {
+    rest.thresholdRate = threshold;
+  }
+
+  // Strip CLI-only entries before forwarding.
+  for (const k of CLI_ONLY_KEYS) {
+    delete (rest as Record<string, unknown>)[k];
+  }
+
   const args = [
     '--',
     actualDir,
@@ -191,5 +231,51 @@ export const compare = (input: CompareInput): EventEmitter => {
     diffDir,
     ...Object.entries(rest).flatMap(([k, v]) => (v == null || v === '' ? [] : [`--${k}`, String(v)])),
   ];
-  return run(args);
+  const inner = run(args);
+
+  // If the caller supplied `update: true` or `junitReport`, we need to do
+  // those side effects AFTER the Wasm run completes but BEFORE emitting
+  // `complete` to the caller — so their handler can observe the final state
+  // on disk. Wrap the inner emitter with one that interposes on `complete`.
+  if (!update && !junitReport) {
+    return inner;
+  }
+
+  const outer = new EventEmitter();
+  inner.on('start', () => outer.emit('start'));
+  inner.on('compare', (p) => outer.emit('compare', p));
+  inner.on('error', (e) => outer.emit('error', e));
+  inner.on('complete', async (data: CompareOutput) => {
+    try {
+      if (junitReport) {
+        const { writeJunit } = await import('./junit');
+        await writeJunit(junitReport, data);
+      }
+      if (update) {
+        await updateExpected(actualDir, expectedDir, data.actualItems ?? []);
+        outer.emit('update');
+      }
+    } catch (e) {
+      outer.emit('error', e);
+      return;
+    }
+    outer.emit('complete', data);
+  });
+
+  return outer;
 };
+
+async function updateExpected(
+  actualDir: string,
+  expectedDir: string,
+  images: string[],
+): Promise<void> {
+  const { mkdir, copyFile } = await import('node:fs/promises');
+  const { dirname, join } = await import('node:path');
+  for (const img of images) {
+    const src = join(actualDir, img);
+    const dst = join(expectedDir, img);
+    await mkdir(dirname(dst), { recursive: true });
+    await copyFile(src, dst);
+  }
+}

--- a/js/junit.ts
+++ b/js/junit.ts
@@ -1,0 +1,75 @@
+import { writeFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import type { CompareOutput } from './';
+
+// Escape XML special characters in attribute / text content.
+const esc = (s: string): string =>
+  s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+/**
+ * Render a JUnit XML report from a reg-cli `CompareOutput` and write it to
+ * `path`. Minimal schema that matches what classic `reg-cli`'s
+ * `src/report.js` produces via `xmlbuilder2`:
+ *
+ *   <testsuites>
+ *     <testsuite name="reg-cli" tests="N" failures="M">
+ *       <testcase name="<path>" classname="reg-cli" />     <-- passed
+ *       <testcase name="<path>" classname="reg-cli">        <-- failed / new / deleted
+ *         <failure message="<kind>" />
+ *       </testcase>
+ *     </testsuite>
+ *   </testsuites>
+ */
+export async function writeJunit(
+  path: string,
+  data: CompareOutput,
+): Promise<void> {
+  const passed = data.passedItems ?? [];
+  const failed = data.failedItems ?? [];
+  const added = data.newItems ?? [];
+  const deleted = data.deletedItems ?? [];
+
+  const cases: string[] = [];
+  for (const name of passed) {
+    cases.push(`    <testcase classname="reg-cli" name="${esc(name)}"/>`);
+  }
+  for (const name of failed) {
+    cases.push(
+      `    <testcase classname="reg-cli" name="${esc(name)}">\n` +
+        `      <failure message="changed" />\n` +
+        `    </testcase>`,
+    );
+  }
+  for (const name of added) {
+    cases.push(
+      `    <testcase classname="reg-cli" name="${esc(name)}">\n` +
+        `      <failure message="new" />\n` +
+        `    </testcase>`,
+    );
+  }
+  for (const name of deleted) {
+    cases.push(
+      `    <testcase classname="reg-cli" name="${esc(name)}">\n` +
+        `      <failure message="deleted" />\n` +
+        `    </testcase>`,
+    );
+  }
+
+  const tests = passed.length + failed.length + added.length + deleted.length;
+  const failures = failed.length + added.length + deleted.length;
+
+  const xml =
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<testsuites>\n` +
+    `  <testsuite name="reg-cli" tests="${tests}" failures="${failures}">\n` +
+    cases.join('\n') +
+    `\n  </testsuite>\n` +
+    `</testsuites>\n`;
+
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, xml, 'utf8');
+}


### PR DESCRIPTION
Stacks on #583 (phase A).

## What this adds

### Library event surface (matches classic reg-cli)

`run()` / `compare()` now emit the same five events classic reg-cli emits:

| event | fired when | payload |
|---|---|---|
| `start` | next tick of the run | `()` |
| `compare` | once per image | `{ type: 'pass' \| 'fail' \| 'new' \| 'delete', path: string }` |
| `update` | after `update: true` copies `actual` → `expected` | `()` |
| `complete` | final, after side effects finish | `CompareOutput` |
| `error` | worker error / side-effect error | `Error` |

The `compare` events are synthesised from the final `JsonReport` right before `complete` (the Wasm side doesn't stream per-image updates; the whole rayon batch lands at once). That's lossy for timing but matches the subscriber API and is enough for spinners / progress bars.

### `compare(input)` actually honours its CLI-only keys

Before, `{ update: true }` and `{ junitReport: '...' }` would be forwarded to Wasm clap as unknown flags and either fail or silently do nothing.

Now `compare()`:

1. Strips `update`, `junitReport`, `extendedErrors` before building the Wasm argv.
2. Translates `threshold` → `thresholdRate` (documented alias).
3. Wraps the inner emitter and intercepts `complete`:
   - If `junitReport` is set, writes `writeJunit(path, data)`.
   - If `update` is set, copies `actualItems` → `expectedDir`, emits `update`.
   - Then emits `complete` (or `error` on failure).
4. Returns the inner emitter unchanged when neither is set — zero overhead for the common path.

### `--junit <path>` CLI flag

Added to `js/cli.ts`. Long-form only (matches classic). Runs `writeJunit()` on `complete`. Honours `-I`.

### `js/junit.ts` (new)

Minimal standalone JUnit XML writer. Same schema as classic reg-cli's `src/report.js` via `xmlbuilder2`:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuites>
  <testsuite name="reg-cli" tests="20" failures="16">
    <testcase classname="reg-cli" name="001.png" />
    <testcase classname="reg-cli" name="005.png">
      <failure message="changed" />
    </testcase>
    ...
  </testsuite>
</testsuites>
```

No new deps (`xmlbuilder2`-level fidelity isn't needed for this document shape).

## Test plan

- [x] Library `compare()`: `start` fires once, `compare` fires 20 times, item counts match the final data.
- [x] Library `compare({ update: true })`: `update` event fires after expected-dir copy completes; verified bytes equal across actual/expected.
- [x] Library `compare({ junitReport: ... })`: file exists, valid XML, counts match.
- [x] CLI `--junit <path>`: writes JUnit XML from the Wasm run.
- [x] Error-path: `compare({ junitReport: '/nonexistent/cant-write/x.xml' })` fires `error`, not an uncaught.

## Out of scope (next phase)

- `-F / --from` (JSON → report without running diff)
- `-X / --additionalDetection`
- Default `--diffFormat png` to match classic output extensions
- `reg.json` written to disk by default
- Streaming per-image `compare` events (requires Rust-side postMessage plumbing)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>