### PR TITLE
CLI compat (phase C): default PNG + always persist reg.json

### DIFF
--- a/js/cli.ts
+++ b/js/cli.ts
@@ -26,7 +26,7 @@
 import { parseArgs } from 'node:util';
 import { copyFile, mkdir } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import { run, type CompareOutput } from './';
+import { run, writeRegJson, type CompareOutput } from './';
 import { writeJunit } from './junit';
 
 const HELP = `
@@ -101,6 +101,10 @@ const update = !!values.update;
 const ignoreChange = !!values.ignoreChange;
 const extendedErrors = !!values.extendedErrors;
 const junitPath = typeof values.junit === 'string' ? values.junit : undefined;
+// Default to matching classic reg-cli: diff images are written as PNG,
+// `./reg.json` is always persisted to disk.
+const diffFormat = typeof values.diffFormat === 'string' ? values.diffFormat : 'png';
+const jsonPath = typeof values.json === 'string' ? values.json : './reg.json';
 const customDiffMessage =
   typeof values.customDiffMessage === 'string'
     ? values.customDiffMessage
@@ -114,14 +118,14 @@ const pushFlag = (name: string, v: unknown): void => {
   else wasmArgv.push(`--${name}`, String(v));
 };
 pushFlag('report', values.report);
-pushFlag('json', values.json);
+pushFlag('json', jsonPath);
 pushFlag('matchingThreshold', values.matchingThreshold);
 pushFlag('thresholdRate', values.thresholdRate);
 pushFlag('thresholdPixel', values.thresholdPixel);
 pushFlag('urlPrefix', values.urlPrefix);
 pushFlag('concurrency', values.concurrency);
 pushFlag('enableAntialias', values.enableAntialias);
-pushFlag('diffFormat', values.diffFormat);
+pushFlag('diffFormat', diffFormat);
 
 const CHECK = '\u2714'; // ✔
 const CROSS = '\u2718'; // ✘
@@ -137,6 +141,17 @@ emitter.once('complete', async (data: CompareOutput) => {
   const passed = data.passedItems ?? [];
   const added = data.newItems ?? [];
   const deleted = data.deletedItems ?? [];
+
+  // Persist the JSON report to disk. Classic reg-cli always does this (the
+  // `-J / --json` flag only controls the path, not whether it's written).
+  try {
+    await writeRegJson(jsonPath, data);
+  } catch (e) {
+    process.stderr.write(
+      `reg-cli: failed to write ${jsonPath} — ${(e as Error).message}\n`,
+    );
+    process.exitCode = 1;
+  }
 
   // Per-file lines (ordering roughly follows classic reg-cli).
   for (const img of passed) process.stdout.write(`${CHECK} pass    ${formatPath(img)}\n`);

--- a/js/index.ts
+++ b/js/index.ts
@@ -214,6 +214,19 @@ const CLI_ONLY_KEYS = new Set<keyof CompareInput>([
 export const compare = (input: CompareInput): EventEmitter => {
   const { actualDir, expectedDir, diffDir, threshold, update, junitReport, ...rest } = input;
 
+  // Default `diffFormat` to png so the JSON/HTML report refers to `*.png`
+  // files — matching classic reg-cli's output and letting downstream
+  // tooling (reg-notify-* / reg-suit) keep working.
+  if ((rest as Record<string, unknown>).diffFormat == null) {
+    (rest as Record<string, unknown>).diffFormat = 'png';
+  }
+
+  // Default `json` to './reg.json' so callers that don't care still get
+  // the persisted report.
+  if (rest.json == null) {
+    rest.json = './reg.json';
+  }
+
   // Translate `threshold` → `thresholdRate` (classic's alias).
   if (threshold != null && rest.thresholdRate == null) {
     rest.thresholdRate = threshold;
@@ -232,21 +245,19 @@ export const compare = (input: CompareInput): EventEmitter => {
     ...Object.entries(rest).flatMap(([k, v]) => (v == null || v === '' ? [] : [`--${k}`, String(v)])),
   ];
   const inner = run(args);
+  const jsonPath = typeof rest.json === 'string' ? rest.json : './reg.json';
 
-  // If the caller supplied `update: true` or `junitReport`, we need to do
-  // those side effects AFTER the Wasm run completes but BEFORE emitting
-  // `complete` to the caller — so their handler can observe the final state
-  // on disk. Wrap the inner emitter with one that interposes on `complete`.
-  if (!update && !junitReport) {
-    return inner;
-  }
-
+  // We always need to persist reg.json on complete (classic does this
+  // whether or not the caller explicitly asked for it). Writing
+  // junitReport / running `update` also needs to happen before we re-emit
+  // `complete` so subscribers see the final on-disk state.
   const outer = new EventEmitter();
   inner.on('start', () => outer.emit('start'));
   inner.on('compare', (p) => outer.emit('compare', p));
   inner.on('error', (e) => outer.emit('error', e));
   inner.on('complete', async (data: CompareOutput) => {
     try {
+      await writeRegJson(jsonPath, data);
       if (junitReport) {
         const { writeJunit } = await import('./junit');
         await writeJunit(junitReport, data);
@@ -264,6 +275,13 @@ export const compare = (input: CompareInput): EventEmitter => {
 
   return outer;
 };
+
+export async function writeRegJson(path: string, data: CompareOutput): Promise<void> {
+  const { writeFile, mkdir } = await import('node:fs/promises');
+  const { dirname } = await import('node:path');
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(data, null, 2) + '\n', 'utf8');
+}
 
 async function updateExpected(
   actualDir: string,


### PR DESCRIPTION
Stacks on #584 (phase B). Closes the last first-class compat gap with classic reg-cli.

## What changes for users

### 1. Default `diffFormat` is now `png`

- **Before**: Wasm defaulted to WebP. `diffItems` in the JSON contained `*.webp` entries and the HTML report loaded WebP images. Downstream consumers of reg-cli's JSON (reg-suit, reg-notify-*, custom bots) broke when swapping classic → Wasm.
- **After**: `cli.ts` and `compare()` default `--diffFormat` to `png` when the caller hasn't specified it. Opt-in WebP is still available via `--diffFormat webp` or `{ diffFormat: 'webp' }`.

### 2. `reg.json` is always written

- **Before**: the Wasm side returned the JSON report as a string through the Worker `complete` message, but nobody wrote it to disk. CIs that read `./reg.json` after running reg-cli saw nothing.
- **After**: `cli.ts` and `compare()` both `writeFile(jsonPath, ...)` immediately before emitting the external `complete`. Default path is `./reg.json` (classic default). Write failures fire `'error'` instead of `'complete'`.

## Implementation notes

- Extracted `writeRegJson()` in `js/index.ts`, exported so `cli.ts` reuses the exact same persistence path.
- Removed the "return inner emitter unchanged" fast-path in `compare()` — writing `reg.json` is now unconditional. Cheap (~KB JSON).

## Test plan

- [x] CLI default: diff dir contains `*.png`, `reg.json` exists, `diffItems` in JSON references `*.png`.
- [x] CLI explicit `--diffFormat webp`: diff dir contains `*.webp`, JSON references `*.webp`.
- [x] Library `compare({ ... })` with no `json`: `./reg.json` written under cwd.
- [x] Library `compare({ json: 'bench/foo/out.json' })`: written to `bench/foo/out.json`, parent dir created if missing.
- [x] Writing to an unwritable path fires `'error'`, not `'complete'`.

## Still not in scope

- `-F / --from` (JSON → HTML without running diff) — limited blast radius
- `-X / --additionalDetection` — report-UI-only setting

Either can land in a follow-up without blocking migration.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>