### PR TITLE
CLI compat (phase I): reg-suit drop-in — strip ignoreChange + enableCliAdditionalDetection

### DIFF
--- a/js/index.ts
+++ b/js/index.ts
@@ -184,6 +184,10 @@ export type CompareInput = {
   additionalDetection?: 'none' | 'client',
   update?: boolean,
   extendedErrors?: boolean,
+  /** Classic reg-cli's `-I/--ignoreChange` — governs the CLI's exit code
+   *  only. Accepted and silently dropped by `compare()` for drop-in
+   *  compat with reg-suit's `processor.ts:107`. */
+  ignoreChange?: boolean,
   urlPrefix?: string,
   matchingThreshold?: number,
   threshold?: number, // alias to thresholdRate.
@@ -192,6 +196,11 @@ export type CompareInput = {
   concurrency?: number,
   enableAntialias?: boolean,
   enableClientAdditionalDetection?: boolean,
+  /** Classic reg-cli's CLI-side x-img-diff extra detection pass. The
+   *  Wasm pipeline's diff already includes the equivalent classification,
+   *  so this is a no-op but accepted for drop-in compat with reg-suit's
+   *  `processor.ts:114`. */
+  enableCliAdditionalDetection?: boolean,
 };
 
 export type CompareOutput = {
@@ -209,9 +218,26 @@ export type CompareOutput = {
 
 /** Flags that `compare()` handles itself in JS; they are NOT forwarded to
  *  the Wasm binary. `extendedErrors` WAS here but now also feeds the
- *  Rust-side junit generator, so it's forwarded below via KEY_REMAP. */
-const CLI_ONLY_KEYS = new Set<keyof CompareInput>([
+ *  Rust-side junit generator, so it's forwarded below via KEY_REMAP.
+ *
+ *  `ignoreChange` and `enableCliAdditionalDetection` are stripped because
+ *  reg-suit unconditionally passes them (see
+ *  reg-viz/reg-suit `packages/reg-suit-core/src/processor.ts` `compare({…})`)
+ *  and the Rust clap layer doesn't recognise them — forwarding would abort
+ *  the binary with "unexpected argument". Semantically both are no-ops at
+ *  the library-event layer:
+ *    - `ignoreChange` only governs classic reg-cli's process exit code;
+ *      the EventEmitter surface never needed it.
+ *    - `enableCliAdditionalDetection` was classic's flag for running an
+ *      extra CLI-side x-img-diff pass; the Wasm port's diff pipeline
+ *      already produces the final pass/fail classification, so toggling
+ *      it changes nothing. (The *client*-side variant is handled via
+ *      `additionalDetection: 'client'` / the legacy
+ *      `enableClientAdditionalDetection: true` alias further down.) */
+const CLI_ONLY_KEYS = new Set<keyof CompareInput | string>([
   'update',
+  'ignoreChange',
+  'enableCliAdditionalDetection',
 ]);
 
 /** Library option names that must be forwarded to the Wasm binary under a

--- a/js/test/library.test.mjs
+++ b/js/test/library.test.mjs
@@ -318,3 +318,47 @@ test('enableClientAdditionalDetection: true is translated to additionalDetection
   const html = await readFile(join(REPO, reportRel), 'utf8');
   assert.match(html, /ximgdiffConfig[^}]*enabled["\\]+:true/);
 });
+
+// ---------------------------------------------------------------------------
+// Phase-I: reg-suit drop-in compatibility
+// ---------------------------------------------------------------------------
+//
+// reg-suit's `packages/reg-suit-core/src/processor.ts` invokes `compare(…)`
+// with a specific option bag every time. Historically we didn't strip
+// `ignoreChange` or `enableCliAdditionalDetection` from the library surface
+// before forwarding args to the Wasm binary, so Rust clap would abort with
+// "unexpected argument" the moment reg-suit tried to invoke us. This test
+// mirrors reg-suit's exact call shape so that regression is caught at the
+// library level.
+//
+// If this test fails, check whether someone removed a key from
+// `CLI_ONLY_KEYS` in `js/index.ts` — those are the keys reg-suit passes
+// unconditionally but our Rust CLI doesn't understand.
+test('reg-suit compat: compare() accepts reg-suit-shaped options without aborting', async () => {
+  const d = await scratch();
+  const emitter = lib.compare({
+    actualDir: `${SAMPLE_REL}/actual`,
+    expectedDir: `${SAMPLE_REL}/expected`,
+    diffDir: `${d.rel}/diff`,
+    json: `${d.rel}/reg.json`,
+    report: `${d.rel}/report.html`,
+    // Verbatim from `reg-suit-core/processor.ts:105-116`:
+    update: false,
+    ignoreChange: true,
+    urlPrefix: '',
+    threshold: undefined,
+    thresholdPixel: undefined,
+    thresholdRate: undefined,
+    matchingThreshold: 0,
+    enableAntialias: undefined,
+    enableCliAdditionalDetection: true, // ximgdiff.invocationType === 'cli'
+    enableClientAdditionalDetection: true, // ximgdiff.invocationType !== 'none'
+    concurrency: 4,
+  });
+  // The original bug: this would never fire — `error` would fire first with
+  // a clap "unexpected argument" abort. Now we strip those keys in
+  // `CLI_ONLY_KEYS` and `compare()` completes cleanly.
+  const { data } = await waitForComplete(emitter);
+  assert.deepEqual(data.failedItems, ['sample0.png']);
+  assert.deepEqual(data.passedItems, ['sample1.png']);
+});


### PR DESCRIPTION
## The bug

reg-viz/reg-suit's `packages/reg-suit-core/src/processor.ts:105-116`
invokes `compare({…})` with two keys the Wasm port's Rust clap layer
does not recognise:

```js
compare({
  actualDir, expectedDir, diffDir, json, report,
  update: false,
  ignoreChange: true,                    // ← not a Rust clap flag
  urlPrefix: '',
  …
  enableCliAdditionalDetection: true,    // ← not a Rust clap flag
  enableClientAdditionalDetection: …,
  …
})
```

`compare()` was forwarding unknown keys verbatim as `--foo value` pairs.
When reg-suit calls us, Rust clap aborts with `error: unexpected
argument '--ignoreChange' found` before the diff loop even runs.

## Fix

Add both to `CLI_ONLY_KEYS` in `js/index.ts` so they're stripped before
forwarding. Semantically both are no-ops at the EventEmitter layer:

- `ignoreChange` only governs classic reg-cli's process exit code; the
  library surface never needed it.
- `enableCliAdditionalDetection` was classic's flag for running an extra
  CLI-side x-img-diff pass during diff. Our Wasm pipeline already
  produces the final pass/fail classification, so toggling it changes
  nothing. (The *client*-side variant is handled separately via
  `additionalDetection: 'client'` / the legacy
  `enableClientAdditionalDetection: true` alias.)

Both keys also added to `CompareInput` TS type so TypeScript users can
pass them without `// @ts-ignore`.

## Tests

New `js/test/library.test.mjs`: `reg-suit compat: compare() accepts
reg-suit-shaped options without aborting` — constructs the exact option
bag from `reg-suit-core/processor.ts` and asserts `complete` fires with
the expected reg.json. Regression tripwire if anyone removes a key from
`CLI_ONLY_KEYS` later.

Full JS: 28/28 passing. Rust: 10/10 unchanged.

## Test plan

- [x] JS full suite 28/28.
- [x] Rust 10/10.
- [x] Manual: copy reg-suit's call verbatim → no more clap abort.
- [ ] CI green on `otel` base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)