### PR TITLE
fix: restore -U option and remove mistakenly committed .only

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 import glob from 'glob'; // $FlowIgnore
 import mkdirp from 'make-dir'; // $FlowIgnore
-import del from 'del'; // $FlowIgnore
+import { deleteAsync } from 'del'; // $FlowIgnore
 import fs from 'fs';
 import path from 'path';
 import { range } from 'lodash';
@@ -107,7 +107,7 @@ const cleanupExpectedDir = (expectedDir, changedFiles) => {
     return escapeGlob(path.posix.join(...directories, image));
   });
   // force: true needed to allow deleting outside working directory
-  return del(paths, { force: true });
+  return deleteAsync(paths, { force: true });
 };
 
 const escapeGlob = fileName => {

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -1,6 +1,5 @@
 import test from 'ava';
 import fs from 'fs';
-import path from 'path';
 import copyfiles from 'copyfiles';
 import rimraf from 'rimraf';
 // $FlowIgnore
@@ -667,7 +666,7 @@ test.serial('perf', async t => {
     const p = spawn(
       './dist/cli.js',
       [`${WORKSPACE}/resource/actual`, `${WORKSPACE}/resource/expected`, `${WORKSPACE}/diff`],
-      { cwd: path.resolve(__dirname, '../') },
+      { cwd: process.cwd() },
     );
     p.on('close', code => resolve(code));
     // p.stdout.on('data', data => console.log(data));

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -46,7 +46,7 @@ test.serial('should display default diff message', async t => {
   t.true(stdout.indexOf('Inspect your code changes, re-run with `-U` to update them') !== -1);
 });
 
-test.serial.only('should display custom diff message', async t => {
+test.serial('should display custom diff message', async t => {
   const stdout = await new Promise(async resolve => {
     const chunks = [];
     rimraf(`${WORKSPACE}/resource/expected`, () => {


### PR DESCRIPTION
## Summary
The `.only` at `test/cli.test.mjs:49` was masking two real failures. Removing it surfaced:

1. **`-U` option crash** — `del` v8 dropped its default export in favor of named `deleteAsync` / `deleteSync`. The babel-compiled `_del.default(...)` was `undefined`, throwing `TypeError: (0 , _del.default) is not a function` whenever `-U` triggered the cleanup path. Switched the import to `{ deleteAsync }`.
2. **`perf` test ESM error** — `__dirname` is not defined in ESM. Replaced `path.resolve(__dirname, '../')` with `process.cwd()` so the file works under both CommonJS and ESM. Other tests in the file already rely on the default cwd.

Also removed the now-unused `path` import from the test file.

## Test plan
- [ ] `grep -rn "\.only(" test/` — no `.only` remains
- [ ] CI runs the full test suite and all tests pass
- [ ] Manual: `./dist/cli.js <actual> <expected> <diff> -U` exits 0 and updates the expected dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)