### PR TITLE
ci: run tests on Ubuntu + macOS + Windows matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,27 @@ permissions:
 
 jobs:
   # Wasm pipeline (the only pipeline now that the legacy JS impl is gone):
-  # uses the committed js/reg.wasm so we don't pay the wasi-sdk toolchain
+  # uses the committed reg.wasm so we don't pay the wasi-sdk toolchain
   # cost on every PR. Rust unit tests (`cargo test`) and the JS CLI/library
-  # integration tests (`node:test` via `pnpm test` in `js/`) both run here
-  # and cover junit/reg.json schema compat, -F/-X/-E, and the `compare()`
+  # integration tests (`node:test` via `pnpm test`) both run here and cover
+  # junit/reg.json schema compat, -F/-X/-E, and the `compare()`
   # EventEmitter surface (reg-suit drop-in).
+  #
+  # Matrix runs on Linux + macOS + Windows so any path-separator,
+  # WASI-sandbox, or shell-script regression is caught before publish.
   test:
-    runs-on: ubuntu-latest
+    name: test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    # Force bash on every OS (Windows runners default to PowerShell). All
+    # our scripts are sh/bash; with `shell: bash` Windows runs them via
+    # the git-bash that ships with the runner image.
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
@@ -22,8 +36,8 @@ jobs:
       # `include_str!`, so `cargo test` fails before we even compile unless
       # we materialise them first. The `build-ui.sh` script clones
       # `reg-viz/reg-cli-report-ui` at a pinned tag and builds it with
-      # yarn (enabled via corepack in setup-node).
-      - name: enable corepack (yarn for report-ui build)
+      # pnpm (enabled via corepack in setup-node).
+      - name: enable corepack (pnpm for report-ui build)
         run: corepack enable
       - name: build report-ui (report.js + style.css)
         run: sh ./scripts/build-ui.sh v0.3.0


### PR DESCRIPTION
## Summary
Single matrix job — same steps as before, just expanded to run on **ubuntu-latest**, **macos-latest**, and **windows-latest** in parallel.

- `shell: bash` forced on every OS → Windows runs the sh/bash scripts (`build-ui.sh`, `build-wasm.sh`) via the runner's git-bash without any rewrite.
- `fail-fast: false` → a Windows-specific failure doesn't cancel the macOS / Linux runs; you see all three at once.

## Why
Things that could (and historically do) break across OSes:
- Path-separator regressions (Windows `\` vs WASI's `/`)
- WASI sandbox preopen behaviour differences across runtimes
- Shell-script portability quirks the Linux-only CI never surfaced

## Test plan
- [ ] CI green on all 3 OSes
- If Windows fails, iterate here (this is the cheapest place to discover it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)