### PR TITLE
fix(windows): normalize wasm-bound paths to absolute POSIX (D:/foo)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,25 +10,24 @@ jobs:
   # integration tests (`node:test` via `pnpm test` in `js/`) both run here
   # and cover junit/reg.json schema compat, -F/-X/-E, and the `compare()`
   # EventEmitter surface (reg-suit drop-in).
-  # Matrix runs on Linux + macOS so any path-separator, WASI-sandbox,
-  # or shell-script regression is caught before publish.
-  #
-  # Windows is intentionally absent: Node's built-in WASI runtime returns
-  # `EINVAL` (`Os { code: 28, kind: InvalidInput }`) when reg.wasm writes
-  # to a preopened relative path (reg.json / report.html / diff/*).
-  # Symptom: `Failed to write ".libtest-…/reg.json"` and ~32/38 tests
-  # fail. The bug is in Node's WASI path translation on Windows
-  # (preopens map to host-absolute Windows paths, but the wasi32 file
-  # syscalls then re-validate the path as POSIX). Not something this
-  # repo can fix — tracked for follow-up; recommend WSL / git-bash for
-  # Windows users in the meantime.
+  # Matrix runs on Linux + macOS + Windows. The `normalizeArgvPathsForWasi`
+  # shim (src/utils.ts) is what keeps Windows passing — Node's WASI on
+  # Windows returns EINVAL for `path_open` of relative paths under a
+  # preopen, so we resolve every path-shaped argv entry to absolute
+  # POSIX form (`D:/a/b/c`) on Windows before forwarding into wasm.
   test:
     name: test (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    # Force bash on every OS (Windows runners default to PowerShell). Our
+    # scripts are sh/bash; with `shell: bash` Windows runs them via the
+    # git-bash that ships with the runner image.
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
@@ -45,9 +44,16 @@ jobs:
       - name: build report-ui (report.js + style.css)
         run: sh ./scripts/build-ui.sh v0.3.0
       - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
+        if: runner.os != 'Windows'
         with:
           toolchain: stable
+      # Skip on Windows: image-diff-rs's host-native build pulls in
+      # libwebp's SSE4.1 intrinsics (`VP8LDspInitSSE41`), which the MSVC
+      # linker can't resolve. The published artefact (reg.wasm) is
+      # built with wasi-sdk's clang and is OS-independent — Windows
+      # users still get full coverage of that via `pnpm test`.
       - name: cargo test (reg_core)
+        if: runner.os != 'Windows'
         run: cargo test -p reg_core --lib
       - name: install
         run: pnpm install --frozen-lockfile

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import EventEmitter from 'node:events';
 import { Worker } from 'node:worker_threads';
-import { isCJS, resolveExtention } from './utils';
+import { isCJS, resolveExtention, normalizeArgvPathsForWasi } from './utils';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'url';
 import {
@@ -28,6 +28,14 @@ const recordMainSpan = (name: string, start_ms: number, attributes?: WorkerSpan[
 };
 
 export const run = (argv: string[]): EventEmitter => {
+  // Windows-only path shim: convert relative path-shaped argv entries to
+  // absolute POSIX-style (`D:/foo/bar`) before forwarding to wasm. Node's
+  // WASI shim on Windows can't resolve relative paths against preopens
+  // reliably (returns EINVAL on `path_open`); absolute POSIX-form paths
+  // sidestep the bug because the shim can match them directly to a
+  // preopen's host directory.
+  argv = normalizeArgvPathsForWasi(argv);
+
   const run_start_ms = Date.now();
 
   // Initialize tracing if enabled (may be ~tens of ms on first run).

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,8 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { readFile } from 'node:fs/promises';
-import { dirname, join, resolve as pathResolve } from 'node:path';
-import { env as procEnv, cwd as procCwd } from 'node:process';
+import { dirname, join, resolve as pathResolve, sep as pathSep } from 'node:path';
+import { env as procEnv, cwd as procCwd, platform as procPlatform } from 'node:process';
 
 export const isCJS = typeof __dirname !== 'undefined';
 
@@ -43,7 +43,10 @@ const commonAncestor = (paths: string[]): string => {
   if (defined.length === 1) return defined[0];
   // If absolute and relative are mixed we can't compute a meaningful common
   // ancestor without risking opening "/". Bail to CWD.
-  const isAbs = (p: string) => p.startsWith('/');
+  // Recognise both POSIX (`/foo`) and Windows-drive (`D:/foo`) forms
+  // because the Windows path shim normalises drives into POSIX-style
+  // paths before they reach `computeWasiSandbox`.
+  const isAbs = (p: string) => p.startsWith('/') || /^[A-Za-z]:\//.test(p);
   const anyAbs = defined.some(isAbs);
   const allAbs = defined.every(isAbs);
   if (anyAbs && !allAbs) return '.';
@@ -162,4 +165,59 @@ export const computeWasiSandbox = (argv: string[]): WasiSandbox => {
   }
 
   return { preopens, env };
+};
+
+/** argv flags whose immediate next entry is a path. Anything else is
+ *  treated as a non-path scalar (numbers, booleans, identifiers like
+ *  `client`, etc.) and left untouched. */
+const PATH_FLAGS = new Set(['--report', '--json', '--junit', '--from', '-F', '-R', '-J']);
+
+/**
+ * On Windows, convert any path-shaped argv entry to absolute POSIX form
+ * (`D:/a/b/c`) before it crosses into wasm.
+ *
+ * Background: Node's WASI shim on Windows can't resolve relative paths
+ * passed to `path_open` against a preopened directory — it returns
+ * `EINVAL` (`Os { code: 28 }`). The wasm CLI then panics on the first
+ * write of `reg.json` / `report.html` / a diff image. Symptom in CI:
+ * `Failed to write ".libtest-…/reg.json"` and ~32/38 tests fail.
+ *
+ * The shim DOES handle absolute POSIX-style paths (`D:/a/b/...`)
+ * correctly — they get matched directly against the host directory
+ * registered as a preopen, no re-resolution required. So we walk argv
+ * here, rewrite the positional dirs and the value following each path-
+ * shaped flag, and let the rest of the pipeline (`computeWasiSandbox`
+ * et al.) handle them as pre-normalised absolute paths.
+ *
+ * No-op on Linux/macOS: those WASI shims handle relative paths
+ * correctly, AND existing tests pin behaviour against relative-path
+ * round-tripping. Skipping the rewrite on POSIX hosts keeps that
+ * coverage honest.
+ */
+export const normalizeArgvPathsForWasi = (argv: string[]): string[] => {
+  if (procPlatform !== 'win32') return argv;
+
+  const toPosix = (p: string): string => {
+    if (!p) return p;
+    const abs = pathResolve(p);
+    return pathSep === '\\' ? abs.split('\\').join('/') : abs;
+  };
+
+  const out = [...argv];
+  // Skip the leading `--` sentinel that `compare()` injects so we land on
+  // the first positional dir (actual / expected / diff).
+  let i = out[0] === '--' ? 1 : 0;
+  let positionalCount = 0;
+  for (; i < out.length && positionalCount < 3; i++) {
+    if (out[i].startsWith('-')) break;
+    out[i] = toPosix(out[i]);
+    positionalCount++;
+  }
+  for (; i < out.length; i++) {
+    if (PATH_FLAGS.has(out[i]) && i + 1 < out.length) {
+      out[i + 1] = toPosix(out[i + 1]);
+      i++;
+    }
+  }
+  return out;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,7 +59,12 @@ const commonAncestor = (paths: string[]): string => {
     else break;
   }
   if (common.length === 0) return allAbs ? '/' : '.';
-  return (allAbs ? '/' : '') + common.join('/');
+  // Windows-drive paths (`D:/foo/bar`) keep the drive letter as the
+  // first segment — adding a leading `/` here would yield `/D:/foo`,
+  // which the WASI shim then re-resolves into `D:\D:\…` (host-side
+  // doubled-drive-letter bug). Detect that case and skip the prefix.
+  const isWindowsDriveAbs = allAbs && /^[A-Za-z]:$/.test(common[0]);
+  return ((allAbs && !isWindowsDriveAbs) ? '/' : '') + common.join('/');
 };
 
 export type WasiSandbox = {


### PR DESCRIPTION
## Summary
Try to make Windows pass on the test matrix.

### Root cause
Node's WASI path translator on Windows returns `EINVAL` (`Os { code: 28, kind: InvalidInput }`) when reg.wasm calls `path_open` on a **relative** path under a preopened directory:

```
Failed to write ".libtest-…/reg.json":
  Os { code: 28, kind: InvalidInput, message: "Invalid argument" }
```

About 32 / 38 tests fail this way. The wasm bytes themselves are fine — it's the JS-side WASI shim. The **absolute POSIX form** (`D:/a/b/c`) DOES work — the shim matches it directly to the host directory mounted at the preopen, no re-resolution required.

### Fix
On Windows only, walk the argv entries that the wasm CLI treats as paths (positional dirs + `--report` / `--json` / `--junit` / `--from` values) and rewrite them to absolute POSIX form. POSIX hosts skip the rewrite entirely so relative-path test coverage stays honest.

```ts
// src/utils.ts
export const normalizeArgvPathsForWasi = (argv: string[]): string[] => {
  if (procPlatform !== 'win32') return argv;
  // …rewrite positionals + path-shaped flag values to D:/foo POSIX form
};

// src/index.ts run()
argv = normalizeArgvPathsForWasi(argv);
```

### Side effects
- `commonAncestor` in `src/utils.ts` now also recognises `[A-Z]:/foo`-shape paths as absolute (otherwise the post-rewrite Windows paths would be treated as relative and fall back to the CWD preopen).
- Re-add `windows-latest` to the CI matrix.
- Cargo test step **still skipped** on Windows — separate libwebp/MSVC linker issue, unrelated to this fix.
- `defaults.run.shell: bash` reinstated for Windows (sh/bash build scripts).

## Test plan
- [x] Local macOS: `pnpm test` → 38 / 38 ✓ (shim is a no-op on POSIX)
- [ ] CI: Windows job passes
- If Windows still fails, the failure pattern will tell us how much further the shim got us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)