### PR TITLE
chore(deps): make @opentelemetry/* optional peer deps (8 → 2 prod deps)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,16 +45,32 @@
   "license": "MIT",
   "dependencies": {
     "@tybys/wasm-util": "^0.9.0",
-    "x-img-diff-js": "^0.3.5",
+    "x-img-diff-js": "^0.3.5"
+  },
+  "peerDependencies": {
     "@opentelemetry/api": "^1.9.1",
-    "@opentelemetry/sdk-trace-base": "^2.7.1",
-    "@opentelemetry/sdk-trace-node": "^2.7.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.216.0",
     "@opentelemetry/resources": "^2.7.1",
+    "@opentelemetry/sdk-trace-base": "^2.7.1",
+    "@opentelemetry/sdk-trace-node": "^2.7.1",
     "@opentelemetry/semantic-conventions": "^1.40.0"
+  },
+  "peerDependenciesMeta": {
+    "@opentelemetry/api": { "optional": true },
+    "@opentelemetry/exporter-trace-otlp-http": { "optional": true },
+    "@opentelemetry/resources": { "optional": true },
+    "@opentelemetry/sdk-trace-base": { "optional": true },
+    "@opentelemetry/sdk-trace-node": { "optional": true },
+    "@opentelemetry/semantic-conventions": { "optional": true }
   },
   "devDependencies": {
     "@types/node": "^22.5.5",
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.216.0",
+    "@opentelemetry/resources": "^2.7.1",
+    "@opentelemetry/sdk-trace-base": "^2.7.1",
+    "@opentelemetry/sdk-trace-node": "^2.7.1",
+    "@opentelemetry/semantic-conventions": "^1.40.0",
     "tsdown": "^0.21.10"
   },
   "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,13 @@ importers:
 
   .:
     dependencies:
+      '@tybys/wasm-util':
+        specifier: ^0.9.0
+        version: 0.9.0(patch_hash=20ebdaec6e1aeb3affd4cb0312df48e2687eac41c9ada11917cff72469fc7210)
+      x-img-diff-js:
+        specifier: ^0.3.5
+        version: 0.3.5
+    devDependencies:
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -31,13 +38,6 @@ importers:
       '@opentelemetry/semantic-conventions':
         specifier: ^1.40.0
         version: 1.40.0
-      '@tybys/wasm-util':
-        specifier: ^0.9.0
-        version: 0.9.0(patch_hash=20ebdaec6e1aeb3affd4cb0312df48e2687eac41c9ada11917cff72469fc7210)
-      x-img-diff-js:
-        specifier: ^0.3.5
-        version: 0.3.5
-    devDependencies:
       '@types/node':
         specifier: ^22.5.5
         version: 22.5.5

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,23 +28,32 @@ const recordMainSpan = (name: string, start_ms: number, attributes?: WorkerSpan[
 };
 
 export const run = (argv: string[]): EventEmitter => {
-  const run_start_ms = Date.now();
-
-  // Initialize tracing if enabled (may be ~tens of ms on first run).
-  const t_init = Date.now();
-  if (isTracingEnabled()) {
-    initTracing();
-    recordMainSpan('main.init_tracing', t_init);
-  }
-
-  // Start root span for the entire operation
-  const traceContext = isTracingEnabled() ? startRootSpan('reg-cli') : null;
-
   const emitter = new EventEmitter();
 
   // Classic reg-cli fires a 'start' event on the next tick of the run so
   // subscribers (e.g. spinners) can latch on. Mirror that behaviour.
   setImmediate(() => emitter.emit('start'));
+
+  // The body needs `await initTracing()` (OTel modules are loaded lazily via
+  // dynamic import so they aren't a forced install dep), but `run` must
+  // return the EventEmitter synchronously. Hand the work off to an async
+  // helper.
+  void runInternal(argv, emitter);
+  return emitter;
+};
+
+const runInternal = async (argv: string[], emitter: EventEmitter): Promise<void> => {
+  const run_start_ms = Date.now();
+
+  // Initialize tracing if enabled (may be ~tens of ms on first run).
+  const t_init = Date.now();
+  if (isTracingEnabled()) {
+    await initTracing();
+    recordMainSpan('main.init_tracing', t_init);
+  }
+
+  // Start root span for the entire operation
+  const traceContext = isTracingEnabled() ? startRootSpan('reg-cli') : null;
 
   const t_new_entry = Date.now();
   const worker = new Worker(join(dir(), `./entry.${resolveExtention()}`), { workerData: { argv } });
@@ -166,8 +175,6 @@ export const run = (argv: string[]): EventEmitter => {
     workers.forEach((w) => w.terminate());
     emitter.emit('error', err);
   });
-
-  return emitter;
 };
 
 export type CompareInput = {

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -3,16 +3,33 @@
  *
  * This module receives trace data from the Rust/WASM side and converts it
  * to OpenTelemetry spans that can be exported to Jaeger or other backends.
+ *
+ * The @opentelemetry/* packages are declared as **optional peer
+ * dependencies** — they are loaded lazily inside `initTracing()` only when
+ * `OTEL_ENABLED=true` (or `JAEGER_ENABLED=true`). Default installs of this
+ * package therefore pay zero install or runtime cost for OTel.
  */
 
-import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
-import { trace, SpanStatusCode, context, ROOT_CONTEXT, type Span, type Context } from '@opentelemetry/api';
-import { resourceFromAttributes } from '@opentelemetry/resources';
-import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
+import type { Span, Context } from '@opentelemetry/api';
 
-let provider: NodeTracerProvider | null = null;
+type OtelApi = typeof import('@opentelemetry/api');
+type OtelResources = typeof import('@opentelemetry/resources');
+type OtelSdkBase = typeof import('@opentelemetry/sdk-trace-base');
+type OtelSdkNode = typeof import('@opentelemetry/sdk-trace-node');
+type OtelExporter = typeof import('@opentelemetry/exporter-trace-otlp-http');
+type OtelSemconv = typeof import('@opentelemetry/semantic-conventions');
+
+interface OtelModules {
+  api: OtelApi;
+  resources: OtelResources;
+  sdkBase: OtelSdkBase;
+  sdkNode: OtelSdkNode;
+  exporter: OtelExporter;
+  semconv: OtelSemconv;
+}
+
+let otel: OtelModules | null = null;
+let provider: InstanceType<OtelSdkNode['NodeTracerProvider']> | null = null;
 let isInitialized = false;
 
 // Store current root span context for propagation to Rust
@@ -62,29 +79,58 @@ export const isTracingEnabled = (): boolean => {
 };
 
 /**
+ * Lazily import the @opentelemetry/* packages. Returns null and prints a
+ * single warning if any are missing — keeps the CLI working without OTel
+ * installed even when the env vars are set.
+ */
+const loadOtel = async (): Promise<OtelModules | null> => {
+  if (otel) return otel;
+  try {
+    const [api, resources, sdkBase, sdkNode, exporter, semconv] = await Promise.all([
+      import('@opentelemetry/api'),
+      import('@opentelemetry/resources'),
+      import('@opentelemetry/sdk-trace-base'),
+      import('@opentelemetry/sdk-trace-node'),
+      import('@opentelemetry/exporter-trace-otlp-http'),
+      import('@opentelemetry/semantic-conventions'),
+    ]);
+    otel = { api, resources, sdkBase, sdkNode, exporter, semconv };
+    return otel;
+  } catch (err) {
+    console.warn(
+      '[Tracing] OTEL_ENABLED is set but @opentelemetry/* packages are not installed. ' +
+        'Install them as peer deps to enable tracing. Continuing without tracing.',
+    );
+    if (process.env.OTEL_DEBUG === 'true') {
+      console.warn('[Tracing] Import error:', err);
+    }
+    return null;
+  }
+};
+
+/**
  * Initialize OpenTelemetry SDK
  */
-export const initTracing = (): void => {
-  if (!isTracingEnabled()) {
+export const initTracing = async (): Promise<void> => {
+  if (!isTracingEnabled() || isInitialized) {
     return;
   }
 
-  if (isInitialized) {
-    return;
-  }
+  const mods = await loadOtel();
+  if (!mods) return;
 
   const otlpEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT || 'http://localhost:4318/v1/traces';
 
-  const otlpExporter = new OTLPTraceExporter({
+  const otlpExporter = new mods.exporter.OTLPTraceExporter({
     url: otlpEndpoint,
   });
 
-  provider = new NodeTracerProvider({
-    resource: resourceFromAttributes({
-      [ATTR_SERVICE_NAME]: 'reg-cli',
-      [ATTR_SERVICE_VERSION]: '0.18.10',
+  provider = new mods.sdkNode.NodeTracerProvider({
+    resource: mods.resources.resourceFromAttributes({
+      [mods.semconv.ATTR_SERVICE_NAME]: 'reg-cli',
+      [mods.semconv.ATTR_SERVICE_VERSION]: '0.18.10',
     }),
-    spanProcessors: [new BatchSpanProcessor(otlpExporter)],
+    spanProcessors: [new mods.sdkBase.BatchSpanProcessor(otlpExporter)],
   });
 
   provider.register();
@@ -127,20 +173,20 @@ export const shutdownTracing = async (): Promise<void> => {
  * Get the tracer instance
  */
 const getTracer = () => {
-  return trace.getTracer('reg-cli-wasm', '0.18.10');
+  return otel!.api.trace.getTracer('reg-cli-wasm', '0.18.10');
 };
 
 /**
  * Start a root span and return context info to pass to Rust
  */
 export const startRootSpan = (name: string): TraceContext | null => {
-  if (!isTracingEnabled() || !isInitialized) {
+  if (!isTracingEnabled() || !isInitialized || !otel) {
     return null;
   }
 
   const tracer = getTracer();
   currentRootSpan = tracer.startSpan(name);
-  currentRootContext = trace.setSpan(ROOT_CONTEXT, currentRootSpan);
+  currentRootContext = otel.api.trace.setSpan(otel.api.ROOT_CONTEXT, currentRootSpan);
 
   // Get the span context to pass to Rust
   const spanContext = currentRootSpan.spanContext();
@@ -161,11 +207,11 @@ export const startRootSpan = (name: string): TraceContext | null => {
  * End the current root span
  */
 export const endRootSpan = (success: boolean = true): void => {
-  if (currentRootSpan) {
+  if (currentRootSpan && otel) {
     if (success) {
-      currentRootSpan.setStatus({ code: SpanStatusCode.OK });
+      currentRootSpan.setStatus({ code: otel.api.SpanStatusCode.OK });
     } else {
-      currentRootSpan.setStatus({ code: SpanStatusCode.ERROR });
+      currentRootSpan.setStatus({ code: otel.api.SpanStatusCode.ERROR });
     }
     currentRootSpan.end();
 
@@ -249,7 +295,7 @@ const topologicalSortSpans = (spans: RustSpanData[]): RustSpanData[] => {
  * we reconstruct them with their recorded timestamps.
  */
 export const processRustTraceData = (traceData: RustTraceData): void => {
-  if (!isTracingEnabled() || !isInitialized) {
+  if (!isTracingEnabled() || !isInitialized || !otel) {
     return;
   }
 
@@ -274,7 +320,7 @@ export const processRustTraceData = (traceData: RustTraceData): void => {
     // Determine parent context
     let parentContext: Context;
     let parentInfo: string;
-    
+
     if (rustSpan.parent_span_id && spanContextMap.has(rustSpan.parent_span_id)) {
       // Has a Rust parent span that was already processed
       parentContext = spanContextMap.get(rustSpan.parent_span_id)!;
@@ -285,9 +331,9 @@ export const processRustTraceData = (traceData: RustTraceData): void => {
       parentInfo = `js parent: ${currentRootSpan?.spanContext().spanId}`;
     } else {
       // No parent available (orphan or parent not found)
-      parentContext = currentRootContext || ROOT_CONTEXT;
-      parentInfo = rustSpan.parent_span_id 
-        ? `orphan (parent ${rustSpan.parent_span_id} not found)` 
+      parentContext = currentRootContext || otel.api.ROOT_CONTEXT;
+      parentInfo = rustSpan.parent_span_id
+        ? `orphan (parent ${rustSpan.parent_span_id} not found)`
         : 'root (no js context)';
     }
 
@@ -313,18 +359,18 @@ export const processRustTraceData = (traceData: RustTraceData): void => {
     // Set status
     if (rustSpan.status === 'error') {
       span.setStatus({
-        code: SpanStatusCode.ERROR,
+        code: otel.api.SpanStatusCode.ERROR,
         message: rustSpan.error_message || 'Unknown error',
       });
     } else {
-      span.setStatus({ code: SpanStatusCode.OK });
+      span.setStatus({ code: otel.api.SpanStatusCode.OK });
     }
 
     // End span with recorded end time
     span.end([Math.floor(endTimeNs / 1_000_000_000), endTimeNs % 1_000_000_000]);
 
     // Store context for child spans
-    const ctx = trace.setSpan(parentContext, span);
+    const ctx = otel.api.trace.setSpan(parentContext, span);
     spanContextMap.set(rustSpan.span_id, ctx);
 
     if (process.env.OTEL_DEBUG === 'true') {
@@ -354,10 +400,10 @@ export const processWorkerSpans = (
   spans: WorkerSpan[],
   workerLabel: string,
 ): void => {
-  if (!isTracingEnabled() || !isInitialized || !spans?.length) return;
+  if (!isTracingEnabled() || !isInitialized || !otel || !spans?.length) return;
 
   const tracer = getTracer();
-  const parentCtx = currentRootContext ?? ROOT_CONTEXT;
+  const parentCtx = currentRootContext ?? otel.api.ROOT_CONTEXT;
 
   for (const s of spans) {
     const startNs = s.start_ms * 1_000_000;
@@ -384,11 +430,12 @@ export const processWorkerSpans = (
  * Create a wrapper span for the entire reg-cli operation
  */
 export const createRootSpan = async <T>(name: string, fn: () => Promise<T>): Promise<T> => {
-  if (!isTracingEnabled() || !isInitialized) {
+  if (!isTracingEnabled() || !isInitialized || !otel) {
     return fn();
   }
 
   const tracer = getTracer();
+  const SpanStatusCode = otel.api.SpanStatusCode;
   return tracer.startActiveSpan(name, async (span) => {
     try {
       const result = await fn();
@@ -406,4 +453,3 @@ export const createRootSpan = async <T>(name: string, fn: () => Promise<T>): Pro
     }
   });
 };
-

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -97,9 +97,19 @@ const loadOtel = async (): Promise<OtelModules | null> => {
     otel = { api, resources, sdkBase, sdkNode, exporter, semconv };
     return otel;
   } catch (err) {
+    const pkgs = [
+      '@opentelemetry/api',
+      '@opentelemetry/exporter-trace-otlp-http',
+      '@opentelemetry/resources',
+      '@opentelemetry/sdk-trace-base',
+      '@opentelemetry/sdk-trace-node',
+      '@opentelemetry/semantic-conventions',
+    ].join(' ');
     console.warn(
-      '[Tracing] OTEL_ENABLED is set but @opentelemetry/* packages are not installed. ' +
-        'Install them as peer deps to enable tracing. Continuing without tracing.',
+      '[Tracing] OTEL_ENABLED is set but the @opentelemetry/* peer dependencies are not installed. ' +
+        'Continuing without tracing. To enable, install the peers alongside reg-cli, e.g.:\n' +
+        `  npm i -g ${pkgs}     # if reg-cli is installed globally\n` +
+        `  npm i    ${pkgs}     # if reg-cli is a project dependency`,
     );
     if (process.env.OTEL_DEBUG === 'true') {
       console.warn('[Tracing] Import error:', err);


### PR DESCRIPTION
## Summary
Tracing only runs when `OTEL_ENABLED=true` (or `JAEGER_ENABLED=true`), so the OpenTelemetry stack doesn't belong in the default install. Move every `@opentelemetry/*` package to `peerDependencies` + `peerDependenciesMeta.<pkg>.optional: true` and load them lazily inside `initTracing()` via `Promise.all(import(...))`.

When OTel is enabled but the peers aren't installed, the CLI prints a one-line warning and continues without tracing — no crash.

## Result
Production dependency count drops from 8 → 2:

| Before | After |
| --- | --- |
| `@tybys/wasm-util` | `@tybys/wasm-util` |
| `x-img-diff-js` | `x-img-diff-js` |
| `@opentelemetry/api` | _(optional peer)_ |
| `@opentelemetry/sdk-trace-base` | _(optional peer)_ |
| `@opentelemetry/sdk-trace-node` | _(optional peer)_ |
| `@opentelemetry/exporter-trace-otlp-http` | _(optional peer)_ |
| `@opentelemetry/resources` | _(optional peer)_ |
| `@opentelemetry/semantic-conventions` | _(optional peer)_ |

Verified with a fresh `npm install --omit=dev` of the packed tarball: only `@tybys/wasm-util` and `x-img-diff-js` (+ their transitives) install.

## Implementation notes
- `src/tracing.ts`: replace top-level OTel imports with a lazy loader that caches the modules at module scope. `import type` from `@opentelemetry/api` is kept for `Span` / `Context` types — TS-erased, so it doesn't pull the package at runtime.
- `src/index.ts`: split `run()` into a sync EventEmitter-returning shim and an async `runInternal()` that can `await initTracing()`. The emitter is returned synchronously as before so callers don't notice.
- `package.json`: OTel packages remain in `devDependencies` so local build/test still has them; tsdown / rolldown leaves the dynamic imports external (verified — built chunks reference `@opentelemetry/*` by name).

## Test plan
- [x] `pnpm test` (no OTel) — 50/50 passing
- [x] `OTEL_ENABLED=true pnpm test` — 50/50 passing (load + warn-or-init paths both exercised)
- [x] Pack + `npm install --omit=dev` of tarball: only the 2 required runtime deps install
- [ ] Optional: end-to-end `OTEL_ENABLED=true` against a real OTLP/HTTP collector

🤖 Generated with [Claude Code](https://claude.com/claude-code)