### PR TITLE
chore(release): make npm publish self-contained (build wasm + report-ui in prepublishOnly)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: enable corepack (yarn for report-ui build)
         run: corepack enable
       - name: build report-ui (report.js + style.css)
-        run: sh ./scripts/build-ui.sh v0.3.0
+        run: sh ./scripts/build-ui.sh v0.5.0
       - uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
         if: runner.os != 'Windows'
         with:

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "build": "tsdown && node ./scripts/stage-assets.mjs",
-    "build:report": "sh ./scripts/build-ui.sh ${REPORT_UI_TAG:-v0.3.0}",
+    "build:report": "sh ./scripts/build-ui.sh ${REPORT_UI_TAG:-v0.5.0}",
     "build:wasm": "bash ./scripts/build-wasm.sh",
     "build:all": "npm run build:report && npm run build:wasm && npm run build",
     "release:prep": "bash ./scripts/release.sh",

--- a/package.json
+++ b/package.json
@@ -29,12 +29,13 @@
   },
   "scripts": {
     "build": "tsdown && node ./scripts/stage-assets.mjs",
-    "build:report": "sh ./scripts/build-ui.sh v0.3.0",
+    "build:report": "sh ./scripts/build-ui.sh ${REPORT_UI_TAG:-v0.3.0}",
     "build:wasm": "bash ./scripts/build-wasm.sh",
+    "build:all": "npm run build:report && npm run build:wasm && npm run build",
     "release:prep": "bash ./scripts/release.sh",
     "release:pack": "bash ./scripts/release.sh --pack",
     "test": "node --test test/",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build:all"
   },
   "repository": {
     "type": "git",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -15,10 +15,10 @@
 # Usage:
 #   scripts/release.sh                       # builds + dry-run pack
 #   scripts/release.sh --pack                # builds + writes the .tgz
-#   REPORT_UI_TAG=v0.5.0 scripts/release.sh  # override the UI version
+#   REPORT_UI_TAG=v0.6.0 scripts/release.sh  # override the UI version
 #
 # Env vars:
-#   REPORT_UI_TAG   default v0.3.0           (passed to build-ui.sh)
+#   REPORT_UI_TAG   default v0.5.0           (passed to build-ui.sh)
 #   SKIP_UI=1       skip the UI build (assumes report/ui/dist/ already exists)
 #   SKIP_WASM=1     skip the wasm rebuild   (assumes ./reg.wasm already exists)
 set -euo pipefail
@@ -27,7 +27,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 cd "$PROJECT_ROOT"
 
-REPORT_UI_TAG="${REPORT_UI_TAG:-v0.3.0}"
+REPORT_UI_TAG="${REPORT_UI_TAG:-v0.5.0}"
 PACK_MODE="--dry-run"
 if [ "${1:-}" = "--pack" ]; then
   PACK_MODE=""


### PR DESCRIPTION
## Summary
- Plain `npm publish` did not rebuild the wasm binary or the report-ui assets. If `./reg.wasm` or `report/ui/dist/*` were missing the publish failed with ENOENT, and if they were stale the package shipped with old artifacts (no detection).
- Add a `build:all` script (`build:report` → `build:wasm` → `build`) and switch `prepublishOnly` to it, so a bare `npm publish` rebuilds everything from source.
- `prepublishOnly` only fires on `npm publish`, not on `npm pack`, so the `npm pack` step inside `scripts/release.sh` does not recurse.
- Allow `build:report` to be overridden via the `REPORT_UI_TAG` env var to match `release.sh`.
- Bump the pinned report-ui tag from `v0.3.0` to `v0.5.0` across `package.json`, `scripts/release.sh`, and `.github/workflows/ci.yml`.

The existing `release:prep` / `release:pack` flows are unchanged.

## Test plan
- [ ] `npm pack --dry-run` still completes quickly (confirms `prepublishOnly` does not run on pack).
- [ ] `npm run build:all` runs report-ui → wasm → tsdown + stage in order, producing `dist/reg.wasm`, `dist/shared/worker_pre.js`, and `dist/shared/report-worker.js`.
- [ ] `npm publish --dry-run` invokes `build:all` via `prepublishOnly`.
- [ ] CI passes with the bumped report-ui tag.