### PR TITLE
chore(rust): bump nightly toolchain pin to 2026-01-01

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2025-01-01"
+channel = "nightly-2026-01-01"
 targets = ["wasm32-wasip1-threads"]


### PR DESCRIPTION
## Summary
The pinned nightly (`nightly-2025-01-01`, rustc 1.85) can no longer build the workspace. With `Cargo.lock` gitignored, each build re-resolves to the latest minor versions, and recent crates require newer rustc:

- `image@0.25.10` requires rustc 1.88
- `icu_*@2.2.x` requires rustc 1.86
- `idna_adapter@1.2.2` requires rustc 1.86

Bump the pinned nightly to `nightly-2026-01-01`. wasi-sdk 25 (used by ` scripts/build-wasm.sh`) remains compatible.

## Test plan
- [x] `bash ./scripts/build-wasm.sh` completes locally on macOS arm64 and produces `./reg.wasm`
- [ ] CI passes