### PR TITLE
chore(release): rename to reg-cli, bump to 0.19.0-rc0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - perf: up to ~2.86× faster than `reg-cli@0.18.16` on large images (see README "Performance")
 - chore: this release was previously published experimentally as `@bokuweb/reg-cli-wasm`; it now takes over the canonical `reg-cli` name on npm
 
+## @0.18.16 (3 May, 2026)
+
+- update dependencies
+
+## @0.18.15 (3 May, 2026)
+
+- update dependencies
+
 ## @0.18.14 (24 Dec, 2025)
 
 - update dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## @0.19.0-rc0 (4 May, 2026)
+
+- feat: Wasm-backed rewrite (Rust + Rayon) — drop-in compatible with the classic `reg-cli` flags, `reg.json`/JUnit schema, and `compare()` EventEmitter API
+- perf: up to ~2.86× faster than `reg-cli@0.18.16` on large images (see README "Performance")
+- chore: this release was previously published experimentally as `@bokuweb/reg-cli-wasm`; it now takes over the canonical `reg-cli` name on npm
+
 ## @0.18.14 (24 Dec, 2025)
 
 - update dependencies

--- a/README.md
+++ b/README.md
@@ -26,10 +26,8 @@ The diff engine is now **Rust → WebAssembly (WASI threads)** instead of pure J
  - Node.js v20+
 
 ```sh
-$ npm i -D @bokuweb/reg-cli-wasm
+$ npm i -D reg-cli
 ```
-
-The published bin is still called `reg-cli`, so existing scripts and `reg-suit` integrations keep working without changes.
 
 ## Usage
 
@@ -95,7 +93,7 @@ JSON format:
 ### Library
 
 ```js
-import { compare } from '@bokuweb/reg-cli-wasm';
+import { compare } from 'reg-cli';
 
 const emitter = compare({
   actualDir: './actual',
@@ -120,7 +118,7 @@ The full option set, event surface, and `CompareOutput` shape match what [`reg-s
 
 Apples-to-apples vs `reg-cli@0.18.16` (last legacy JS release), `--diffFormat png` on both sides, 5 timed runs after 1 warmup, median wall-clock on macOS (Apple Silicon) / Node v20.19.0:
 
-| Workload | JS reg-cli@0.18.16 | @bokuweb/reg-cli-wasm | Wasm speedup |
+| Workload | JS reg-cli@0.18.16 | reg-cli@0.19.0-rc0 | Wasm speedup |
 |---|---:|---:|---:|
 | 20 × 1280×720 | 0.56 s | 0.49 s | **1.14×** |
 | 100 × 1280×720 | 1.94 s | 1.44 s | **1.35×** |

--- a/crates/reg_core/src/tracing_layer.rs
+++ b/crates/reg_core/src/tracing_layer.rs
@@ -301,7 +301,7 @@ pub fn get_trace_data_json() -> String {
     };
     
     let trace_data = TraceData {
-        service_name: "reg-cli-wasm".to_string(),
+        service_name: "reg-cli".to_string(),
         trace_id,
         js_parent_span_id,
         spans,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@bokuweb/reg-cli-wasm",
-  "version": "0.0.0-experimental6",
+  "name": "reg-cli",
+  "version": "0.19.0-rc0",
   "description": "Visual regression testing CLI, Wasm-backed. Drop-in compatible with classic reg-cli's CLI flags, reg.json/junit schema, and `compare()` EventEmitter API (verified against reg-suit's processor.ts).",
   "type": "module",
   "exports": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,8 +3,8 @@
 // CLI wrapper around the Wasm `run()` entry point.
 //
 // Goal: match the surface of classic reg-cli (`src/cli.js`) closely enough
-// that users migrating from `reg-cli` to `@bokuweb/reg-cli-wasm` do not have
-// to change their CI invocation. Specifically this handles:
+// that existing `reg-cli` users do not have to change their CI invocation.
+// Specifically this handles:
 //
 //   - POSIX short-flag aliases (-R, -J, -M, -T, -S, -C, -A, -I, -E, -U, -D)
 //   - Non-zero exit code on pixel diff (`process.exitCode = 1`)

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -183,7 +183,7 @@ export const shutdownTracing = async (): Promise<void> => {
  * Get the tracer instance
  */
 const getTracer = () => {
-  return otel!.api.trace.getTracer('reg-cli-wasm', '0.18.10');
+  return otel!.api.trace.getTracer('reg-cli', '0.19.0-rc0');
 };
 
 /**

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -10,7 +10,22 @@
  * package therefore pay zero install or runtime cost for OTel.
  */
 
+import { createRequire } from 'node:module';
+
 import type { Span, Context } from '@opentelemetry/api';
+
+// Read once at module load so getTracer() doesn't hit the disk per call.
+// `../package.json` resolves relative to the *built* dist/ output; tsdown
+// keeps the relative path intact.
+const PKG_VERSION: string = (() => {
+  try {
+    const requireShim = createRequire(import.meta.url);
+    const pkg = requireShim('../package.json') as { version?: string };
+    return pkg.version ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+})();
 
 type OtelApi = typeof import('@opentelemetry/api');
 type OtelResources = typeof import('@opentelemetry/resources');
@@ -183,7 +198,7 @@ export const shutdownTracing = async (): Promise<void> => {
  * Get the tracer instance
  */
 const getTracer = () => {
-  return otel!.api.trace.getTracer('reg-cli', '0.19.0-rc0');
+  return otel!.api.trace.getTracer('reg-cli', PKG_VERSION);
 };
 
 /**

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -373,8 +373,7 @@ test('-D custom diff message shows up on failure', async () => {
 test('--version prints the package.json version', async () => {
   const { code, stdout } = await runCli(['--version']);
   assert.equal(code, 0);
-  // Must look like semver-ish (at least digits + dot), not the classic
-  // "reg-cli-wasm" placeholder.
+  // Must look like semver-ish (at least digits + dot), not a placeholder.
   assert.match(stdout.trim(), /^\d+\.\d+\.\d+/);
 });
 

--- a/test/library.test.mjs
+++ b/test/library.test.mjs
@@ -470,3 +470,12 @@ test('compare() does NOT fire `error` when a single image fails to decode', asyn
     `expected a fail compare-event for bad.png; got ${JSON.stringify(compareEvents)}`,
   );
 });
+
+// reg-suit's `processor.ts` does `require.resolve('reg-cli')` to locate this
+// package, and its CLI is invoked as `reg-cli`. Lock the published name and
+// bin so a future rename can't silently break the drop-in story.
+test('package.json publishes as `reg-cli` with a `reg-cli` bin', async () => {
+  const pkg = JSON.parse(await readFile(join(REPO, 'package.json'), 'utf8'));
+  assert.equal(pkg.name, 'reg-cli', 'npm name must be `reg-cli`');
+  assert.ok(pkg.bin && pkg.bin['reg-cli'], 'must expose a `reg-cli` bin');
+});


### PR DESCRIPTION
## Summary
- Rename npm package `@bokuweb/reg-cli-wasm` → `reg-cli` (taking over the canonical name on npm)
- Bump version `0.0.0-experimental6` → `0.19.0-rc0`
- Update README install/import snippets and perf-table header
- Tidy CLI/README wording that framed this package as a *migration target* — it is now `reg-cli` itself

## Test plan
- [ ] `cat package.json | jq '.name, .version'` → `"reg-cli"`, `"0.19.0-rc0"`
- [ ] `grep -r "@bokuweb/reg-cli-wasm" .` returns no matches outside `node_modules`/`dist`
- [ ] `npm run build` succeeds
- [ ] `npm pack --dry-run` produces `reg-cli-0.19.0-rc0.tgz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)