### PR TITLE
ci(sample-report): pass -I so deploy proceeds when sample has diffs

### DIFF
--- a/.github/workflows/deploy-sample-report.yml
+++ b/.github/workflows/deploy-sample-report.yml
@@ -35,7 +35,7 @@ jobs:
           mkdir -p public
           cp -r sample/actual sample/expected sample/diff public/
           node dist/cli.mjs ./sample/actual ./sample/expected ./sample/diff \
-            -R public/index.html -X client
+            -R public/index.html -X client -I
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: public


### PR DESCRIPTION
## Summary

Add `-I` (`--ignoreChange`) to the sample-report generation step in `.github/workflows/deploy-sample-report.yml`.

## Why

The sample fixtures under `sample/` intentionally include a changed image (`sample0.png`) so the deployed report demonstrates the failed-items UI. Without `-I`, `reg-cli` exits 1 on any detected diff and the subsequent `upload-pages-artifact` / `deploy-pages` jobs never run — the deploy is gated on a pass that the demo is designed not to produce.

Observed failure on the previous run:
```
✘ change  sample/actual/sample0.png
✘ 1 file(s) changed.
Error: Process completed with exit code 1.
```

## Test plan

- [ ] Workflow run on this branch (manual `workflow_dispatch`) completes both `build` and `deploy` jobs
- [ ] Deployed Pages URL renders the report including the failed-items section

🤖 Generated with [Claude Code](https://claude.com/claude-code)