### PR TITLE
ci(sample-report): place fixtures inside public/ so image paths resolve on Pages

### DIFF
--- a/.github/workflows/deploy-sample-report.yml
+++ b/.github/workflows/deploy-sample-report.yml
@@ -32,9 +32,10 @@ jobs:
         run: pnpm build
       - name: generate sample report
         run: |
-          mkdir -p public
-          cp -r sample/actual sample/expected sample/diff public/
-          node dist/cli.mjs ./sample/actual ./sample/expected ./sample/diff \
+          mkdir -p public/diff
+          cp -r sample/actual public/actual
+          cp -r sample/expected public/expected
+          node dist/cli.mjs ./public/actual ./public/expected ./public/diff \
             -R public/index.html -X client -I
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:


### PR DESCRIPTION
## Summary

Run `reg-cli` against `public/{actual,expected,diff}` instead of `sample/{actual,expected,diff}` when generating the deployed report.

## Why

The deployed report rendered with broken image thumbnails. The report's `actualDir` / `expectedDir` / `diffDir` are computed by [`resolve_dir`](crates/reg_core/src/dir.rs:18) as paths relative to the report HTML (see [report.rs:198-211](crates/reg_core/src/report.rs:198)).

Previously the workflow:
1. Copied fixtures into `public/` (`cp -r sample/actual sample/expected sample/diff public/`)
2. But invoked `reg-cli` with the **original** `./sample/actual` paths

So `resolve_dir("public/index.html", "./sample/actual")` → `../sample/actual`, and the deployed `public/index.html` linked to `../sample/actual/sample0.png` — a path outside the uploaded Pages artifact. Hence the broken-image icons under `CHANGED ITEMS`.

Fix: pass paths inside `public/` so relative resolution lands at `./actual/...` within the artifact.

## Test plan

- [ ] Workflow run on this branch deploys successfully
- [ ] `CHANGED ITEMS` thumbnails (and the failed-items detail view) load on the deployed Pages site

🤖 Generated with [Claude Code](https://claude.com/claude-code)