### PR TITLE
ci(sample-report): cd into public/ for clean relative image paths

### DIFF
--- a/.github/workflows/deploy-sample-report.yml
+++ b/.github/workflows/deploy-sample-report.yml
@@ -35,8 +35,9 @@ jobs:
           mkdir -p public/diff
           cp -r sample/actual public/actual
           cp -r sample/expected public/expected
-          node dist/cli.mjs ./public/actual ./public/expected ./public/diff \
-            -R public/index.html -X client -I
+          CLI=$(node -e "console.log(require('path').resolve('dist/cli.mjs'))")
+          cd public && node "$CLI" ./actual ./expected ./diff \
+            -R ./index.html -X client -I
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: public


### PR DESCRIPTION
## Summary

`cd public && node …/cli.mjs ./actual ./expected ./diff -R ./index.html` instead of running from repo root with `./public/...` paths.

## Why

Deployed report still served broken images:
\`\`\`
GET https://reg-viz.github.io/public/diff/sample0.png 404
GET https://reg-viz.github.io/public/actual/sample1.png 404
\`\`\`

The HTML embedded `actualDir` / `expectedDir` / `diffDir` with a `public/` prefix because `resolve_dir(report, actual_dir)` was computing paths relative to the report from the **repo-root** invocation. The browser, resolving those relative paths against the project Pages base, hit `/public/...` instead of `/reg-cli/<dir>/...`.

Running the CLI from inside `public/` makes `resolve_dir` yield plain `actual` / `expected` / `diff` (matching what the old hand-committed `docs/index.html` had: `"actualDir":"./actual"`).

The CLI path is resolved to absolute via `node -e` first because the worker bundle uses `import.meta.url` to locate sibling assets and we don't want that broken by `cd`.

## Test plan

- [ ] Workflow run deploys; `CHANGED ITEMS` thumbnails load on the deployed site
- [ ] Network panel shows requests to `https://reg-viz.github.io/reg-cli/{actual,expected,diff}/...` with 200s

🤖 Generated with [Claude Code](https://claude.com/claude-code)