### PR TITLE
security(wasm): pass only declared WASI imports to instantiate

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import { WASI, type IFs } from '@tybys/wasm-util';
 import { env } from 'node:process';
 import { parentPort, workerData } from 'node:worker_threads';
-import { computeWasiSandbox, readWasm } from './utils';
+import { computeWasiSandbox, filterWasiImports, readWasm } from './utils';
 import { createPrintErrHook } from './progress';
 import { type RustTraceData, type WorkerSpan } from './tracing';
 
@@ -66,7 +66,6 @@ const wasi = new WASI({
   printErr,
 });
 
-const imports = wasi.getImportObject();
 const file = readWasm();
 
 /**
@@ -99,9 +98,14 @@ const readWasmString = (
     const opts = { initial: 256, maximum: 16384, shared: true };
     const memory = new WebAssembly.Memory(opts);
 
+    const wasi_snapshot_preview1 = filterWasiImports(
+      wasm,
+      wasi.getImportObject().wasi_snapshot_preview1,
+    );
+
     let instance = await tSpan('entry.wasm_instantiate', async () =>
       WebAssembly.instantiate(wasm, {
-        ...imports,
+        wasi_snapshot_preview1,
         wasi: {
           'thread-spawn': (startArg: number) => {
             const threadIdBuffer = new SharedArrayBuffer(4);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,6 +17,32 @@ export const resolveExtention = (): string => {
 };
 
 /**
+ * Restrict the WASI namespace passed to `WebAssembly.instantiate` to only the
+ * functions the wasm module actually imports. `@tybys/wasm-util` exposes the
+ * full WASI preview1 surface (~46 fns) but `reg.wasm` declares ~20. The unused
+ * 26 include capabilities reg-cli never needs (`path_unlink_file`,
+ * `path_remove_directory`, `sock_*`, `proc_raise`, ...). Withholding them
+ * shrinks the blast radius if the bundled wasm or one of its image-decoder
+ * dependencies (libpng/libwebp/libjpeg) is ever compromised.
+ */
+export const filterWasiImports = (
+  module: WebAssembly.Module,
+  full: WebAssembly.ModuleImports,
+): WebAssembly.ModuleImports => {
+  const needed = new Set(
+    WebAssembly.Module.imports(module)
+      .filter((i) => i.module === 'wasi_snapshot_preview1')
+      .map((i) => i.name),
+  );
+  const filtered: Record<string, unknown> = {};
+  const src = full as unknown as Record<string, unknown>;
+  for (const name of needed) {
+    if (name in src) filtered[name] = src[name];
+  }
+  return filtered as WebAssembly.ModuleImports;
+};
+
+/**
  * Host environment variables intentionally forwarded into the Wasm sandbox.
  * Everything else (shell secrets, CI credentials, AWS_*, NPM_TOKEN, ...) is
  * filtered out.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -2,7 +2,12 @@ import { parentPort, workerData } from 'node:worker_threads';
 import fs from 'node:fs';
 import { WASI, type IFs } from '@tybys/wasm-util';
 import { argv, env } from 'node:process';
-import { computeWasiSandbox, readWasm, resolveExtention } from './utils';
+import {
+  computeWasiSandbox,
+  filterWasiImports,
+  readWasm,
+  resolveExtention,
+} from './utils';
 // https://github.com/toyobayashi/emnapi/blob/5ab92c706c7cd4a0a30759e58f26eedfb0ded591/packages/wasi-threads/src/wasi-threads.ts#L288-L335
 import { createInstanceProxy } from './proxy';
 import { createPrintErrHook } from './progress';
@@ -34,7 +39,6 @@ const wasi = new WASI({
   printErr,
 });
 
-const imports = wasi.getImportObject();
 const file = readWasm();
 
 const handler = async ({ startArg, tid, memory }: { startArg: number, tid: number, memory: WebAssembly.Memory }) => {
@@ -65,9 +69,14 @@ const handler = async ({ startArg, tid, memory }: { startArg: number, tid: numbe
       WebAssembly.compile(await file),
     );
 
+    const wasi_snapshot_preview1 = filterWasiImports(
+      wasm,
+      wasi.getImportObject().wasi_snapshot_preview1,
+    );
+
     let instance = await tSpan('worker.wasm_instantiate', async () =>
       WebAssembly.instantiate(wasm, {
-        ...imports,
+        wasi_snapshot_preview1,
         wasi: {
           'thread-spawn': (startArg: number) => {
             const threadIdBuffer = new SharedArrayBuffer(4);


### PR DESCRIPTION
## Summary

`@tybys/wasm-util`'s WASI exposes **46** `wasi_snapshot_preview1` functions, but `reg.wasm` only imports **20**. The other 26 were reachable from the wasm instance despite the Rust code never declaring them.

This PR filters the WASI import namespace down to exactly the names returned by `WebAssembly.Module.imports(wasm)`, so the capability surface is bounded by what the bundled wasm actually declares.

### Capabilities no longer exposed (26)

- **File mutation**: `path_unlink_file`, `path_remove_directory`, `path_rename`, `path_symlink`, `path_link`, `path_filestat_set_times`, `fd_filestat_set_size`, `fd_filestat_set_times`, `fd_allocate`, `fd_pwrite`, `fd_renumber`, `fd_sync`, `fd_datasync`
- **Network**: `sock_accept`, `sock_recv`, `sock_send`, `sock_shutdown`
- **Process / signals**: `proc_raise`, `poll_oneoff`
- **Other**: `clock_res_get`, `fd_advise`, `fd_fdstat_set_flags`, `fd_fdstat_set_rights`, `fd_pread`, `fd_tell`, `path_readlink`

### Why this matters

reg-cli ingests untrusted images from CI and the wasm pipeline embeds image decoders (libpng / libwebp / libjpeg) which have a long history of RCE-class CVEs. If the wasm process is ever compromised, withholding unused WASI capabilities — especially file mutation and sockets — meaningfully shrinks blast radius. Same principle as the existing preopen-narrowing in `computeWasiSandbox`.

### Implementation

- New `filterWasiImports(module, full)` helper in [src/utils.ts](src/utils.ts): inspects `WebAssembly.Module.imports(module)` and returns a namespace containing only the functions wasm actually declares. Dynamic — no allowlist to maintain.
- [src/entry.ts](src/entry.ts) and [src/worker.ts](src/worker.ts) call it after `WebAssembly.compile` and pass the filtered object to `WebAssembly.instantiate`.

## Test plan

- [x] `pnpm build` (tsdown step succeeds; the unrelated `stage-assets` step needs the prebuilt report UI which isn't in scope here)
- [x] `pnpm test` — 47/51 pass, identical to baseline `main`; the 4 failing tests are pre-existing and depend on the same prebuilt report UI
- [x] End-to-end smoke: `node dist/cli.cjs sample/actual sample/expected sample/diff -I` produces the expected pass/change output
- [x] Sanity check: filtered namespace is `20` entries (down from `46`), matching wasm's declared imports exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)