### PR TITLE
ci: rename coronarium → sakimori and use the new one-step `run:` input

### DIFF
--- a/.github/sakimori.yml
+++ b/.github/sakimori.yml
@@ -9,12 +9,12 @@ network:
   # `default: deny` was attempted but isn't viable for this workload:
   # registry.npmjs.org / github releases / crates.io are CDN-fronted
   # (Cloudflare / Fastly) anycast pools that rotate IPs across /12
-  # ranges faster than coronarium's 15s DNS refresh can keep up.
+  # ranges faster than sakimori's 15s DNS refresh can keep up.
   # Trying to allow Cloudflare's published v4/v6 ranges instead
   # overflows the eBPF map (`HashMap::with_max_entries(1024)`), with
   # `bpf_map_update_elem failed: Argument list too long`.
   #
-  # Until coronarium grows an LPM-trie-backed prefix map, fall back
+  # Until sakimori grows an LPM-trie-backed prefix map, fall back
   # to default-allow on the network pillar. Real defence-in-depth
   # for this CI lives in `process.deny_exec` (block exfil tools) and
   # `file.deny` (sensitive paths), both of which work as advertised.
@@ -28,7 +28,7 @@ file:
   # match `/lib/`, `/etc/`, etc. prefixes, so they fall through to
   # the default-deny verdict and inflate `stats.denied`. pnpm
   # install of ~800 packages produces thousands of such fds and
-  # block mode exits non-zero on every run. Until coronarium
+  # block mode exits non-zero on every run. Until sakimori
   # treats non-`/`-prefixed paths as "not a real path, don't deny"
   # (sibling fix to the empty-string handling already in v0.31.0),
   # default-deny on the file pillar isn't viable.
@@ -38,7 +38,7 @@ file:
   # regardless of the default verdict.
   default: allow
   deny:
-    # coronarium kernel-blocks only the first 8 prefixes (eBPF map
+    # sakimori kernel-blocks only the first 8 prefixes (eBPF map
     # capacity). Entries past slot 8 don't actually block — they're
     # tagged as denied in the JSON log only — but they still
     # increment `stats.denied`, which makes block mode exit
@@ -70,7 +70,7 @@ file:
     # is low.
     #
     # NOTE: Windows credential paths are also intentionally absent.
-    # coronarium-win runs in `--mode audit` here, where any deny
+    # sakimori-win runs in `--mode audit` here, where any deny
     # tag would still trip the block-mode counter check on Linux
     # (same policy file, both OSes). If we want Windows-specific
     # deny rules later, switch to per-OS policy files.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,22 +39,8 @@ jobs:
         with:
           toolchain: stable
 
-      # Install the coronarium binary on Linux + Windows. macOS is
-      # left unsupervised (coronarium's supervised mode is Linux /
-      # Windows only — see the upstream runner-support matrix).
-      - uses: bokuweb/coronarium@v0
-        if: runner.os != 'macOS'
-        with:
-          policy: .github/coronarium.yml
-          mode: block
-
-      # Single supervised script that runs every `run:` step under
-      # the coronarium policy: corepack enable → report-ui build
-      # (clones reg-cli-report-ui from GitHub) → cargo test (fetches
-      # crates.io deps; Linux only) → pnpm install (fetches from
-      # registry.npmjs.org) → pnpm build → pnpm test. Anything that
-      # tries to connect outside the policy's allow-list, open a
-      # sensitive path, or exec a banned tool fails the run.
+      # macOS is left unsupervised — sakimori's supervised mode is
+      # Linux / Windows only (see the upstream runner-support matrix).
       - name: full CI script — macOS, unsupervised
         if: runner.os == 'macOS'
         run: |
@@ -66,68 +52,70 @@ jobs:
           pnpm build
           pnpm test
 
-      - name: full CI script — Linux, coronarium block
+      # Linux: one-step form — the action installs sakimori AND
+      # executes the supervised script under `sakimori run` for us.
+      # No separate `sudo -E env "PATH=$PATH" "$SAKIMORI_BIN" run …`
+      # step needed. Hostname allow rules (github.com,
+      # registry.npmjs.org, …) are re-resolved every 15s by
+      # sakimori's default — needed because those hostnames use
+      # GeoDNS round-robin and the IP the supervised child gets
+      # mid-run can differ from the one captured at startup.
+      - name: full CI script — Linux, sakimori block
         if: runner.os == 'Linux'
-        run: |
-          # `sudo -E` preserves env *except* PATH; `env "PATH=$PATH"`
-          # re-injects the runner user's PATH so the supervised
-          # child can find pnpm/cargo/git. Hostname allow rules
-          # (github.com, registry.npmjs.org, …) are re-resolved
-          # every 15s by coronarium's default — needed because
-          # those hostnames use GeoDNS round-robin and the IP the
-          # supervised child gets mid-run can differ from the one
-          # captured at startup.
-          sudo -E env "PATH=$PATH" "$CORONARIUM_BIN" run \
-            --policy  "$CORONARIUM_POLICY" \
-            --mode    "$CORONARIUM_MODE" \
-            --log     coronarium.log.json \
-            --html    coronarium-report.html \
-            --summary "$GITHUB_STEP_SUMMARY" \
-            -- bash -euxo pipefail -c '
-              corepack enable
-              sh ./scripts/build-ui.sh v0.5.0
-              cargo test -p reg_core --lib
-              pnpm install --frozen-lockfile
-              pnpm build
-              pnpm test
-            '
+        uses: bokuweb/sakimori@v0
+        with:
+          policy: .github/sakimori.yml
+          mode: block
+          log: sakimori.log.json
+          html: sakimori-report.html
+          run: |
+            corepack enable
+            sh ./scripts/build-ui.sh v0.5.0
+            cargo test -p reg_core --lib
+            pnpm install --frozen-lockfile
+            pnpm build
+            pnpm test
 
-      - name: full CI script — Windows, coronarium audit
+      # Windows: the action's bundled `run:` wrapper is pwsh-only,
+      # and this script needs bash (build-ui.sh + && chains) plus a
+      # per-OS `--mode audit` override (sakimori-win itself warns
+      # that `network.default=deny` is audit-only — Windows Defender
+      # Firewall has no clean default-outbound-deny primitive, so
+      # sakimori-win tags every TLS connect as `denied` in the log
+      # without actually blocking it; in `--mode block` the
+      # resulting `denied > 0` makes the run exit non-zero on tests
+      # that were never blocked). So we keep the explicit form here.
+      # No cargo on Windows either (libwebp SSE4.1 intrinsics issue
+      # on the host-native build — see setup-rust-toolchain above).
+      - uses: bokuweb/sakimori@v0
+        if: runner.os == 'Windows'
+        with:
+          policy: .github/sakimori.yml
+          mode: block
+      - name: full CI script — Windows, sakimori audit
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          # No cargo on Windows (libwebp SSE4.1 intrinsics issue —
-          # see comment on setup-rust-toolchain above).
-          #
-          # Force `--mode audit` on Windows. coronarium-win itself
-          # warns that `network.default=deny` is audit-only — Windows
-          # Defender Firewall has no clean default-outbound-deny
-          # primitive, so coronarium-win tags every TLS connect as
-          # `denied` in the log without actually blocking it. In
-          # `--mode block` the resulting `denied > 0` makes the run
-          # exit non-zero on tests that were never blocked, so we
-          # downgrade Windows to audit-only and rely on Linux for
-          # real enforcement.
-          & $env:CORONARIUM_BIN `
-            --policy $env:CORONARIUM_POLICY `
+          & $env:SAKIMORI_BIN `
+            --policy $env:SAKIMORI_POLICY `
             --mode   audit `
-            --log    coronarium.log.json `
-            --html   coronarium-report.html `
+            --log    sakimori.log.json `
+            --html   sakimori-report.html `
             -- bash -euxo pipefail -c "corepack enable && sh ./scripts/build-ui.sh v0.5.0 && pnpm install --frozen-lockfile && pnpm build && pnpm test"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always() && runner.os != 'macOS'
         with:
-          name: coronarium-report-${{ matrix.os }}
+          name: sakimori-report-${{ matrix.os }}
           path: |
-            coronarium-report.html
-            coronarium.log.json
+            sakimori-report.html
+            sakimori.log.json
           if-no-files-found: ignore
 
-      - uses: bokuweb/coronarium/comment@v0
+      - uses: bokuweb/sakimori/comment@v0
         if: runner.os == 'Linux' && github.event_name == 'pull_request'
         with:
-          log: coronarium.log.json
-          artifact-name: coronarium-report-${{ matrix.os }}
-          html-filename: coronarium-report.html
+          log: sakimori.log.json
+          artifact-name: sakimori-report-${{ matrix.os }}
+          html-filename: sakimori-report.html


### PR DESCRIPTION
## Summary
- The supply-chain guard repo was renamed from [bokuweb/coronarium](https://github.com/bokuweb/sakimori) to [bokuweb/sakimori](https://github.com/bokuweb/sakimori). Rename the policy file (`.github/coronarium.yml` → `.github/sakimori.yml`), env-var references (`CORONARIUM_*` → `SAKIMORI_*`), action refs, and the log/report artefact names so CI keeps working against the new home.
- Take advantage of sakimori v0.33's new `run:` input on the Linux job — the action installs sakimori AND wraps the script under `sakimori run`, so the explicit `sudo -E env "PATH=$PATH" "$SAKIMORI_BIN" run …` step collapses into the action invocation itself.
- Windows stays in the explicit form (the action's bundled `run:` wrapper executes pwsh, but this script needs bash; Windows also still needs the `--mode audit` per-step override).
- macOS remains unsupervised (sakimori is Linux/Windows only).

Diff highlights on the Linux step:

Before:
```yaml
- uses: bokuweb/coronarium@v0
  if: runner.os != 'macOS'
  with:
    policy: .github/coronarium.yml
    mode: block
- name: full CI script — Linux, coronarium block
  if: runner.os == 'Linux'
  run: |
    sudo -E env "PATH=$PATH" "$CORONARIUM_BIN" run \
      --policy  "$CORONARIUM_POLICY" \
      --mode    "$CORONARIUM_MODE" \
      --log     coronarium.log.json \
      --html    coronarium-report.html \
      --summary "$GITHUB_STEP_SUMMARY" \
      -- bash -euxo pipefail -c '
        corepack enable
        sh ./scripts/build-ui.sh v0.5.0
        cargo test -p reg_core --lib
        pnpm install --frozen-lockfile
        pnpm build
        pnpm test
      '
```

After:
```yaml
- name: full CI script — Linux, sakimori block
  if: runner.os == 'Linux'
  uses: bokuweb/sakimori@v0
  with:
    policy: .github/sakimori.yml
    mode: block
    log: sakimori.log.json
    html: sakimori-report.html
    run: |
      corepack enable
      sh ./scripts/build-ui.sh v0.5.0
      cargo test -p reg_core --lib
      pnpm install --frozen-lockfile
      pnpm build
      pnpm test
```

## Test plan
- [ ] CI green on this PR across all three runner OSes (Linux block-mode supervised, Windows audit-mode supervised, macOS unsupervised).
- [ ] PR comment posted by `bokuweb/sakimori/comment@v0` on the Linux job.
- [ ] `sakimori-report-${os}` artefacts uploaded on Linux + Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)