### PR TITLE
ci: use `bokuweb/sakimori/job/stop@v0` sub-action for mid-job flush

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,17 +96,13 @@ jobs:
             -- bash -euxo pipefail -c "corepack enable && sh ./scripts/build-ui.sh v0.5.0 && pnpm install --frozen-lockfile && pnpm build && pnpm test"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-      # Force the Linux daemon to flush its log + HTML mid-job so the
-      # upload-artifact / comment steps below can see them. The
-      # action's post-hook also calls `daemon stop`, but it runs at
-      # the very end of the job — long after upload-artifact has
-      # already executed. `daemon stop` is idempotent on a missing
-      # pid-file, so the post-hook becomes a no-op.
-      - if: always() && runner.os == 'Linux'
-        name: Flush sakimori daemon
-        run: |
-          sudo -n -E "$SAKIMORI_BIN" daemon stop \
-            --pid-file "$SAKIMORI_JOB_PIDFILE"
+      # Flush the Linux daemon so upload-artifact + the comment
+      # sub-action below see the freshly-written log + HTML. The
+      # daemon's own post-hook would otherwise write them at
+      # end-of-job, too late for an in-job upload. Sub-action is
+      # idempotent and a no-op on non-Linux entries.
+      - if: always()
+        uses: bokuweb/sakimori/job/stop@v0
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always() && runner.os != 'macOS'


### PR DESCRIPTION
sakimori v0.34.4 shipped a 1-line sub-action that wraps the verbose `daemon stop` snippet (https://github.com/bokuweb/sakimori/pull/64). Swap the 4-line block in for the sub-action — same idempotent / Linux-only-no-op semantics, less leaking implementation detail.

**Before**
```yaml
- if: always() && runner.os == 'Linux'
  name: Flush sakimori daemon
  run: |
    sudo -n -E "$SAKIMORI_BIN" daemon stop \
      --pid-file "$SAKIMORI_JOB_PIDFILE"
```

**After**
```yaml
- if: always()
  uses: bokuweb/sakimori/job/stop@v0
```

The `runner.os == 'Linux'` guard goes away too — the sub-action already no-ops on macOS / Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)