### PR TITLE
build(wasm): bump linear memory cap from 1 GiB to 4 GiB

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,13 @@
+# wasm32 linear memory has a 4 GiB (1 << 32 bytes) architectural ceiling.
+# With wasm-ld's default --max-memory (= 1 GiB), comparing large PNGs makes
+# the in-wasm dlmalloc inside reg.wasm fail memory.grow and abort with
+# `memory allocation of ... bytes failed`, which wasmtime then surfaces as
+# a `wasm trap: unreachable`.
+#
+# Declare the maximum as `(memory ... max=65536 pages)` = 4 GiB by passing
+# the flag through to wasm-ld at link time. memory.grow still only commits
+# pages on demand, so idle RSS is unchanged — this only lifts the ceiling.
+[target.wasm32-wasip1-threads]
+rustflags = [
+  "-C", "link-arg=--max-memory=4294967296",
+]


### PR DESCRIPTION
## Summary

Bump the linear-memory cap of `reg.wasm` from **1 GiB → 4 GiB (the wasm32 architectural maximum)**.

### Background

When diffing very large PNGs (e.g. high-resolution docx renderings around 8000×8000 px), reg-actions surfaces the following crash (reported in [reg-viz/reg-actions#220](https://github.com/reg-viz/reg-actions/pull/220)):

```
memory allocation of 260995200 bytes failed
Caused by: wasm trap: wasm `unreachable` instruction executed
```

- 260,995,200 bytes ≈ a single 8077×8077 RGBA buffer.
- The current `reg.wasm` declares `(import "env" "memory" ... shared min=22 max=16384)`, i.e. **max = 16384 pages = 1 GiB**.
- Once cumulative usage approaches 1 GiB, `memory.grow` refuses the next few-hundred-MB block requested by the in-wasm dlmalloc.
- Rust's wasm allocator then aborts with an alloc error, which wasmtime surfaces as `unreachable`.

For the `wasm32-wasip1-threads` target this ceiling is fixed at link time — `wasm-ld`'s default `--max-memory` is 1 GiB.

### Change

Add `.cargo/config.toml` so the wasm build passes `-C link-arg=--max-memory=4294967296` to `wasm-ld`. The emitted `(import ... memory ... max=N)` becomes **65536 pages (= 4 GiB, the wasm32 maximum)**.

`memory.grow` still only commits pages on demand, so idle RSS is unchanged — this only lifts the ceiling.

### Verification

Rebuilt locally with `scripts/build-wasm.sh` and inspected the memory import:

before:
```
IMPORT memory env.memory: flags=0x3 min=27 pages max=16384 pages (1.00 GiB)
```

after:
```
IMPORT memory env.memory: flags=0x3 min=22 pages max=65536 pages (4.00 GiB)
```

## Test plan

- [ ] `pnpm build` (or `scripts/build-wasm.sh`) produces `reg.wasm` successfully
- [ ] Existing tests stay green
- [ ] Large PNGs (~8000×8000) no longer trigger OOM

## Related

- [reg-viz/reg-actions#220](https://github.com/reg-viz/reg-actions/pull/220) — companion change that raises wasmtime's host-side memory reservation