### PR TITLE
fix(deps): update protobufjs to 8.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   "packageManager": "pnpm@10.33.3+sha512.a19744364a7e248b92657a4ca5973f9354d21caf982579674b1c539f32c7420c47138ad8b1254df07aba9bc782d9b3029e3db34d5dbff974326eb74dac8ff489",
   "pnpm": {
     "overrides": {
-      "protobufjs": "^8.3.0"
+      "protobufjs": "^8.6.5"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  protobufjs: ^8.3.0
+  protobufjs: ^8.6.5
 
 importers:
 
@@ -462,8 +462,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  protobufjs@8.3.0:
-    resolution: {integrity: sha512-JpJpFaR7yKNb6WqKvJJ1MLbiuIQWQnbUUb06nDtf2/i8YWYYLEfP6xf9BwSJoJQg1wAy61EQB8dssQg64oX4aA==}
+  protobufjs@8.8.0:
+    resolution: {integrity: sha512-N3xhQ5yyBx3vQq4gubBfASzYhJGNzeDbjqBpu61g7UVylsN/qyffU96TKWD3GbbLOKF82VGNRNvv1+BFgE31Eg==}
     engines: {node: '>=12.0.0'}
 
   quansync@1.0.0:
@@ -686,7 +686,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.216.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
-      protobufjs: 8.3.0
+      protobufjs: 8.8.0
 
   '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -892,7 +892,7 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  protobufjs@8.3.0:
+  protobufjs@8.8.0:
     dependencies:
       long: 5.3.2
 


### PR DESCRIPTION
## What does this change?

- Raises the protobufjs pnpm override from ^8.3.0 to ^8.6.5.
- Regenerates the lockfile, resolving protobufjs to 8.8.0.
- Fixes CVE-2026-59876 / GHSA-jfj6-75fj-8934.

## References

- https://github.com/reg-viz/reg-cli/security/dependabot/144
- https://github.com/advisories/GHSA-jfj6-75fj-8934

## Screenshots

Not applicable.

## What can I check for bug fixes?

- pnpm install --frozen-lockfile
- sh ./scripts/build-ui.sh v0.5.0
- pnpm build
- pnpm test (51 tests passed)
- pnpm why protobufjs reports only protobufjs 8.8.0.