### PR TITLE
fix: support relative paths starting with ./

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -11,7 +11,12 @@ import fs from 'node:fs';
 import { WASI, type IFs } from '@tybys/wasm-util';
 import { env } from 'node:process';
 import { parentPort, workerData } from 'node:worker_threads';
-import { computeWasiSandbox, filterWasiImports, readWasm } from './utils';
+import {
+  computeWasiSandbox,
+  filterWasiImports,
+  normalizeWasiArgv,
+  readWasm,
+} from './utils';
 import { createInstanceProxy } from './proxy';
 import { createPrintErrHook } from './progress';
 import { type RustTraceData, type WorkerSpan } from './tracing';
@@ -22,7 +27,8 @@ const mode: Mode = workerData.mode;
 const isTracingEnabled = (): boolean =>
   env.OTEL_ENABLED === 'true' || env.JAEGER_ENABLED === 'true';
 
-const sandbox = computeWasiSandbox(workerData.argv);
+const argv = normalizeWasiArgv(workerData.argv);
+const sandbox = computeWasiSandbox(argv);
 
 const printErr = createPrintErrHook((ev) => {
   parentPort?.postMessage({ cmd: 'compare-event', event: ev });
@@ -30,7 +36,7 @@ const printErr = createPrintErrHook((ev) => {
 
 const wasi = new WASI({
   version: 'preview1',
-  args: workerData.argv,
+  args: argv,
   env: sandbox.env,
   returnOnExit: true,
   preopens: sandbox.preopens,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,6 +92,41 @@ export type WasiSandbox = {
   env: Record<string, string>;
 };
 
+const WASI_PATH_FLAGS = new Set([
+  '--report',
+  '-R',
+  '--json',
+  '-J',
+  '--junit',
+  '--from',
+  '-F',
+]);
+
+/**
+ * Normalize `./foo` to `foo` for paths passed into WASI. wasm-util does not
+ * match a guest path beginning with `./` to an otherwise equivalent relative
+ * preopen, so leaving the prefix intact makes valid paths unreachable.
+ */
+export const normalizeWasiArgv = (argv: string[]): string[] => {
+  const normalized = [...argv];
+  const stripDot = (value: string): string =>
+    value.startsWith('./') ? value.slice(2) || '.' : value;
+  const offset = normalized[0] === '--' ? 1 : 0;
+
+  for (let i = offset; i < normalized.length && i < offset + 3; i++) {
+    if (normalized[i].startsWith('-')) break;
+    normalized[i] = stripDot(normalized[i]);
+  }
+  for (let i = offset; i < normalized.length - 1; i++) {
+    if (WASI_PATH_FLAGS.has(normalized[i])) {
+      normalized[i + 1] = stripDot(normalized[i + 1]);
+      i++;
+    }
+  }
+
+  return normalized;
+};
+
 /**
  * Compute the minimum-capability WASI sandbox for a given reg-cli invocation:
  *

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -122,6 +122,40 @@ test('missing positional dirs prints error and exits non-zero', async () => {
   assert.match(stderr, /actual.*expected.*diff/i);
 });
 
+test('accepts relative paths starting with ./', async () => {
+  const d = await scratch();
+  const dot = (path) => `./${path}`;
+  const actualRel = `${d.rel}/actual`;
+  const expectedRel = `${d.rel}/expected`;
+  const jsonRel = `${d.rel}/reg.json`;
+  const reportRel = `${d.rel}/report.html`;
+  await mkdir(join(REPO, actualRel), { recursive: true });
+  await mkdir(join(REPO, expectedRel), { recursive: true });
+  await cp(
+    join(REPO, SAMPLE_REL, 'actual/sample1.png'),
+    join(REPO, actualRel, 'sample1.png'),
+  );
+  await cp(
+    join(REPO, SAMPLE_REL, 'expected/sample1.png'),
+    join(REPO, expectedRel, 'sample1.png'),
+  );
+  const { code, stderr } = await runCli([
+    dot(actualRel),
+    dot(expectedRel),
+    dot(`${d.rel}/diff`),
+    '-J',
+    dot(jsonRel),
+    '-R',
+    dot(reportRel),
+    '-I',
+  ]);
+
+  assert.equal(code, 0, stderr);
+  const report = JSON.parse(await readFile(join(REPO, jsonRel), 'utf8'));
+  assert.ok(report.actualItems.includes('sample1.png'));
+  await stat(join(REPO, reportRel));
+});
+
 // ---------------------------------------------------------------------------
 // reg.json schema compat
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this change?

Normalize filesystem arguments that start with ./ before passing them to WASI. This keeps positional directories and report, JSON, JUnit, and from paths resolvable within the existing minimal preopen sandbox.

A regression test covers an invocation where every input and output path starts with ./.

## References

Fixes #669

## Screenshots

Not applicable.

## What can I check for bug fixes?

Run the new accepts relative paths starting with ./ CLI test. It reproduces the preopen descriptor error before the implementation change and passes afterward.

## Verification

- pnpm build
- node --test --test-name-pattern="accepts relative paths starting with" test/cli.test.mjs