### PR TITLE
Speed up image comparison pipeline

### DIFF
--- a/crates/reg_core/Cargo.toml
+++ b/crates/reg_core/Cargo.toml
@@ -10,7 +10,7 @@ name = "reg_core"
 path = "src/lib.rs"
 
 [dependencies]
-image-diff-rs = { git = "https://github.com/bokuweb/image-diff-rs.git", tag = "0.1.1" }
+image-diff-rs = { git = "https://github.com/bokuweb/image-diff-rs.git", tag = "0.1.2" }
 rayon = "1.8"
 mustache = "0.9.0"
 serde = { version = "1.0.207", features = ["derive"] }

--- a/crates/reg_core/benches/run.rs
+++ b/crates/reg_core/benches/run.rs
@@ -11,14 +11,11 @@ const TINY_PNG: &[u8] = &[
     0x42, 0x60, 0x82,
 ];
 
-// 1x1 PNG with a single black pixel — differs from TINY_PNG by 1 pixel
-const TINY_PNG_BLACK: &[u8] = &[
-    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
-    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
-    0x89, 0x00, 0x00, 0x00, 0x10, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x62, 0x60, 0x60, 0x60, 0x60,
-    0x00, 0x00, 0x00, 0x05, 0x00, 0x01, 0x5e, 0xf3, 0x2a, 0x3a, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45,
-    0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
-];
+// Real 800x578 screenshots. The previous hand-written "black PNG" fixture
+// had an invalid deflate stream, so the benchmark measured decode failures
+// instead of pixel comparison and diff encoding.
+const SAMPLE_DIFF_ACTUAL: &[u8] = include_bytes!("../../../sample/actual/sample0.png");
+const SAMPLE_DIFF_EXPECTED: &[u8] = include_bytes!("../../../sample/expected/sample0.png");
 
 struct Fixture {
     _root: TempDir,
@@ -55,8 +52,8 @@ fn make_fixture(n_equal: usize, n_diff: usize, nest: bool) -> Fixture {
     }
     for i in 0..n_diff {
         let name = format!("diff{:04}.png", i);
-        std::fs::write(actual.join(&name), TINY_PNG_BLACK).unwrap();
-        std::fs::write(expected.join(&name), TINY_PNG).unwrap();
+        std::fs::write(actual.join(&name), SAMPLE_DIFF_ACTUAL).unwrap();
+        std::fs::write(expected.join(&name), SAMPLE_DIFF_EXPECTED).unwrap();
     }
     Fixture {
         _root: root,
@@ -128,5 +125,33 @@ fn bench_find_images_only(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_run_all_equal, bench_run_with_diffs, bench_find_images_only);
+fn bench_threshold_accepted_diffs(c: &mut Criterion) {
+    // All ten screenshots differ, but thresholdRate=1 accepts them. This
+    // specifically catches regressions where we encode diff images before
+    // learning that no output file is needed.
+    let fixture = make_fixture(0, 10, false);
+    let mut group = c.benchmark_group("threshold_accepted_diffs");
+    group.sample_size(15);
+    group.throughput(Throughput::Elements(10));
+    group.bench_function("10_accepted_diffs", |b| {
+        b.iter(|| {
+            let json = fixture.diff.join("reg.json");
+            let opts = Options {
+                json: Some(Path::new(&json) as &Path),
+                threshold_rate: Some(1.0),
+                ..Options::default()
+            };
+            let _ = run(&fixture.actual, &fixture.expected, &fixture.diff, opts).unwrap();
+        });
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_run_all_equal,
+    bench_run_with_diffs,
+    bench_find_images_only,
+    bench_threshold_accepted_diffs
+);
 criterion_main!(benches);

--- a/crates/reg_core/src/lib.rs
+++ b/crates/reg_core/src/lib.rs
@@ -52,7 +52,9 @@ static DEFAULT_REPORT_PATH: &'static str = "./report.html";
 ///
 /// Format (one event per line, TAB-delimited, newline-terminated):
 ///
+/// ```text
 ///     __REG_CLI_EVT__\t{"type":"pass|fail|new|delete","path":"..."}\n
+/// ```
 ///
 /// Everything else on stderr is forwarded through to `console.error` on the
 /// host, so actual errors still reach users.
@@ -227,6 +229,7 @@ pub fn run(
     let expected_dir = expected_dir.as_ref();
     let diff_dir = diff_dir.as_ref();
     let json_path = options.json.unwrap_or_else(|| Path::new(DEFAULT_JSON_PATH));
+    let render_html = options.report.is_some();
     let report = options
         .report
         .unwrap_or_else(|| Path::new(DEFAULT_REPORT_PATH));
@@ -251,169 +254,204 @@ pub fn run(
         emit_progress("delete", &p.display().to_string());
     }
 
-    let targets: Vec<PathBuf> = detected
+    // Keep borrowed paths here. Each path only needs to be cloned once, when
+    // it enters its final passed/failed result set.
+    let targets: Vec<&Path> = detected
         .actual
         .intersection(&detected.expected)
-        .cloned()
+        .map(PathBuf::as_path)
         .collect();
 
-    // Match classic reg-cli (src/index.js:77): for small image sets the
-    // rayon thread-pool spin-up + cross-thread span dance costs more than
-    // any parallelism buys. Force single-threaded until we cross the
-    // classic's 20-image threshold.
-    let concurrency = if targets.len() < 20 {
-        1
-    } else {
-        options.concurrency.unwrap_or(4)
-    };
-    info!(target_count = targets.len(), concurrency, "Starting parallel image diff");
+    // Tiny batches lose more to Rayon/Node worker startup than they gain from
+    // parallelism. Large screenshots are different: even ten 800x578 inputs
+    // have enough decode/compare work to amortize worker startup. Use encoded
+    // byte size as a cheap proxy while retaining classic reg-cli's 20-image
+    // cutoff for batches of small files.
+    const MIN_PARALLEL_IMAGES: usize = 4;
+    const PARALLEL_IMAGE_COUNT: usize = 20;
+    const PARALLEL_ENCODED_BYTES: u64 = 256 * 1024;
 
-    let pool = {
-        let _pool_span = info_span!("build_thread_pool", num_threads = concurrency).entered();
-        ThreadPoolBuilder::new()
-            .num_threads(concurrency)
-            .build()
-            .unwrap()
+    let requested_concurrency = options.concurrency.unwrap_or(4);
+    let encoded_bytes = if requested_concurrency > 1
+        && targets.len() >= MIN_PARALLEL_IMAGES
+        && targets.len() < PARALLEL_IMAGE_COUNT
+    {
+        targets
+            .iter()
+            .filter_map(|path| std::fs::metadata(actual_dir.join(path)).ok())
+            .map(|metadata| metadata.len())
+            .try_fold(0_u64, |total, len| {
+                let total = total.saturating_add(len);
+                (total < PARALLEL_ENCODED_BYTES).then_some(total)
+            })
+            .unwrap_or(PARALLEL_ENCODED_BYTES)
+    } else {
+        0
     };
+    let parallel_worthwhile = targets.len() >= PARALLEL_IMAGE_COUNT
+        || (targets.len() >= MIN_PARALLEL_IMAGES && encoded_bytes >= PARALLEL_ENCODED_BYTES);
+    let concurrency = if parallel_worthwhile {
+        requested_concurrency
+    } else {
+        1
+    };
+    info!(
+        target_count = targets.len(),
+        concurrency, "Starting parallel image diff"
+    );
 
     let result = {
         let diff_span = info_span!("parallel_image_diff", target_count = targets.len());
         let _diff_guard = diff_span.enter();
-        
+
         // Capture the parent span to propagate to rayon threads
         let parent_span = diff_span.clone();
-        
-        pool.install(|| {
-            // Note: There may be ~20-30ms delay here due to rayon thread scheduling overhead
-            // This is especially noticeable in WASI environments
-            targets
-                .par_iter()
-                .map(|path| -> Result<(PathBuf, ImageOutcome), CompareError> {
-                    // Explicitly set parent span for cross-thread context propagation
-                    let image_span = info_span!(parent: parent_span.clone(), "diff_single_image", image = %path.display());
-                    let _image_guard = image_span.enter();
 
-                    let actual_path = actual_dir.join(path);
-                    let expected_path = expected_dir.join(path);
+        let compare_target = |path: &&Path| -> Result<(PathBuf, ImageOutcome), CompareError> {
+            let path = *path;
+            // Explicitly set parent span for cross-thread context propagation
+            let image_span = info_span!(parent: parent_span.clone(), "diff_single_image", image = %path.display());
+            let _image_guard = image_span.enter();
 
-                    // Per-file failure policy: read OR decode errors are
-                    // logged to stderr, classified as "fail" via a live
-                    // compare-event, and counted into `failedItems`. We
-                    // never propagate them up — one corrupt PNG must not
-                    // abort a 1000-image batch (parity with classic
-                    // reg-cli, which forks-per-image and tolerates child
-                    // crashes individually).
-                    let img1 = match std::fs::read(&actual_path) {
-                        Ok(b) => b,
-                        Err(e) => {
-                            eprintln!(
-                                "[reg-cli] failed to read actual {}: {}",
-                                actual_path.display(),
-                                e
-                            );
-                            emit_progress("fail", &path.display().to_string());
-                            return Ok((path.clone(), ImageOutcome::Failed));
-                        }
-                    };
-                    let img2 = match std::fs::read(&expected_path) {
-                        Ok(b) => b,
-                        Err(e) => {
-                            eprintln!(
-                                "[reg-cli] failed to read expected {}: {}",
-                                expected_path.display(),
-                                e
-                            );
-                            emit_progress("fail", &path.display().to_string());
-                            return Ok((path.clone(), ImageOutcome::Failed));
-                        }
-                    };
+            let actual_path = actual_dir.join(path);
+            let expected_path = expected_dir.join(path);
 
-                    let res = match image_diff_rs::diff(
-                        img1,
-                        img2,
-                        &DiffOption {
-                            threshold: options.matching_threshold,
-                            include_anti_alias: Some(!options.enable_antialias.unwrap_or_default()),
-                            encode_format: options
-                                .diff_image_format
-                                .map(EncodeFormat::from),
-                        },
-                    ) {
-                        Ok(r) => r,
+            // Per-file failure policy: read OR decode errors are
+            // logged to stderr, classified as "fail" via a live
+            // compare-event, and counted into `failedItems`. We
+            // never propagate them up — one corrupt PNG must not
+            // abort a 1000-image batch (parity with classic
+            // reg-cli, which forks-per-image and tolerates child
+            // crashes individually).
+            let img1 = match std::fs::read(&actual_path) {
+                Ok(b) => b,
+                Err(e) => {
+                    eprintln!(
+                        "[reg-cli] failed to read actual {}: {}",
+                        actual_path.display(),
+                        e
+                    );
+                    emit_progress("fail", &path.display().to_string());
+                    return Ok((path.to_path_buf(), ImageOutcome::Failed));
+                }
+            };
+            let img2 = match std::fs::read(&expected_path) {
+                Ok(b) => b,
+                Err(e) => {
+                    eprintln!(
+                        "[reg-cli] failed to read expected {}: {}",
+                        expected_path.display(),
+                        e
+                    );
+                    emit_progress("fail", &path.display().to_string());
+                    return Ok((path.to_path_buf(), ImageOutcome::Failed));
+                }
+            };
+
+            let outcome = if img1 == img2 {
+                // Preserve image-diff-rs's encoded-byte equality fast
+                // path without decoding either image.
+                ImageOutcome::Passed
+            } else {
+                let diff_option = DiffOption {
+                    threshold: options.matching_threshold,
+                    include_anti_alias: Some(!options.enable_antialias.unwrap_or_default()),
+                    encode_format: options.diff_image_format.map(EncodeFormat::from),
+                };
+                let rgba = match image_diff_rs::diff_rgba(&img1, &img2, &diff_option) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        let path_str = path.display().to_string();
+                        eprintln!("[reg-cli] failed to diff {}: {}", path_str, e);
+                        emit_progress("fail", &path_str);
+                        return Ok((path.to_path_buf(), ImageOutcome::Failed));
+                    }
+                };
+
+                if is_passed(
+                    rgba.width,
+                    rgba.height,
+                    rgba.diff_count as u64,
+                    options.threshold_pixel,
+                    options.threshold_rate,
+                ) {
+                    // Accepted differences do not need a diff image.
+                    // Avoiding PNG/WebP encoding is the important fast
+                    // path enabled by image-diff-rs PR #35.
+                    ImageOutcome::Passed
+                } else {
+                    let format = options.diff_image_format.unwrap_or_default();
+                    let encoded = match image_diff_rs::encode_diff(&rgba, format.into()) {
+                        Ok(DiffOutput::NotEq { diff_image, .. }) => diff_image,
+                        Ok(DiffOutput::Eq) => unreachable!("encoding an RGBA diff cannot be equal"),
                         Err(e) => {
                             let path_str = path.display().to_string();
-                            eprintln!("[reg-cli] failed to diff {}: {}", path_str, e);
+                            eprintln!("[reg-cli] failed to encode diff {}: {}", path_str, e);
                             emit_progress("fail", &path_str);
-                            return Ok((path.clone(), ImageOutcome::Failed));
+                            return Ok((path.to_path_buf(), ImageOutcome::Failed));
                         }
                     };
 
-                    // Write each encoded diff before starting another image.
-                    // Keeping every DiffOutput in the collected result retains
-                    // all diff-image buffers until the whole parallel batch
-                    // finishes, which can exhaust wasm32's 4 GiB address space
-                    // on large, highly-different screenshot sets.
-                    let outcome = match res {
-                        DiffOutput::Eq => ImageOutcome::Passed,
-                        DiffOutput::NotEq {
-                            diff_count,
-                            diff_image,
-                            width,
-                            height,
-                        } => {
-                            if is_passed(
-                                width,
-                                height,
-                                diff_count as u64,
-                                options.threshold_pixel,
-                                options.threshold_rate,
-                            ) {
-                                ImageOutcome::Passed
-                            } else {
-                                let mut diff_image_name = path.clone();
-                                diff_image_name.set_extension(
-                                    options
-                                        .diff_image_format
-                                        .unwrap_or_default()
-                                        .extension(),
-                                );
-                                let diff_path = diff_dir.join(&diff_image_name);
-                                if let Some(parent) = diff_path.parent() {
-                                    std::fs::create_dir_all(parent).map_err(|e| {
-                                        eprintln!(
-                                            "Failed to create diff directory: {:?}, error: {:?}",
-                                            parent, e
-                                        );
-                                        e
-                                    })?;
-                                }
-                                std::fs::write(&diff_path, diff_image).map_err(|e| {
-                                    eprintln!(
-                                        "Failed to write diff file: {:?}, error: {:?}",
-                                        diff_path, e
-                                    );
-                                    e
-                                })?;
-                                ImageOutcome::Different(diff_image_name)
-                            }
-                        }
-                    };
+                    // Write each encoded diff before starting another
+                    // image so buffers are released promptly.
+                    let mut diff_image_name = path.to_path_buf();
+                    diff_image_name.set_extension(format.extension());
+                    let diff_path = diff_dir.join(&diff_image_name);
+                    if let Some(parent) = diff_path.parent() {
+                        std::fs::create_dir_all(parent).map_err(|e| {
+                            eprintln!(
+                                "Failed to create diff directory: {:?}, error: {:?}",
+                                parent, e
+                            );
+                            e
+                        })?;
+                    }
+                    std::fs::write(&diff_path, encoded).map_err(|e| {
+                        eprintln!("Failed to write diff file: {:?}, error: {:?}", diff_path, e);
+                        e
+                    })?;
+                    ImageOutcome::Different(diff_image_name)
+                }
+            };
 
-                    // Fire the live pass/fail event as soon as this image and
-                    // (when needed) its diff file are complete, while other
-                    // rayon workers continue processing the batch.
-                    let kind = match &outcome {
-                        ImageOutcome::Passed => "pass",
-                        ImageOutcome::Failed | ImageOutcome::Different(_) => "fail",
-                    };
-                    // Avoid the second `path.display().to_string()` allocation
-                    // by using `to_string_lossy()` which borrows on UTF-8 paths.
-                    emit_progress(kind, &path.to_string_lossy());
+            // Fire the live pass/fail event as soon as this image and
+            // (when needed) its diff file are complete, while other
+            // rayon workers continue processing the batch.
+            let kind = match &outcome {
+                ImageOutcome::Passed => "pass",
+                ImageOutcome::Failed | ImageOutcome::Different(_) => "fail",
+            };
+            // Avoid the second `path.display().to_string()` allocation
+            // by using `to_string_lossy()` which borrows on UTF-8 paths.
+            emit_progress(kind, &path.to_string_lossy());
 
-                    Ok((path.clone(), outcome))
-                })
+            Ok((path.to_path_buf(), outcome))
+        };
+
+        if concurrency == 1 {
+            // Small batches are faster in-place and, in WASI, this also
+            // avoids starting a Node worker just to run a single Rayon
+            // thread.
+            targets
+                .iter()
+                .map(&compare_target)
                 .collect::<Result<Vec<(PathBuf, ImageOutcome)>, CompareError>>()
-        })
+        } else {
+            let pool = {
+                let _pool_span =
+                    info_span!("build_thread_pool", num_threads = concurrency).entered();
+                ThreadPoolBuilder::new()
+                    .num_threads(concurrency)
+                    .build()
+                    .unwrap()
+            };
+            pool.install(|| {
+                targets
+                    .par_iter()
+                    .map(&compare_target)
+                    .collect::<Result<Vec<(PathBuf, ImageOutcome)>, CompareError>>()
+            })
+        }
     }?;
 
     let mut differences = BTreeSet::new();
@@ -454,6 +492,7 @@ pub fn run(
             actual: detected.actual,
             expected: detected.expected,
             report,
+            render_html,
             differences,
             json: json_path,
             actual_dir,
@@ -562,6 +601,7 @@ pub fn run_from_json(
             expected: json.expected_items.clone(),
             differences: json.diff_items.clone(),
             report: report_path,
+            render_html: true,
             json: out_json_path,
             actual_dir: Path::new(&json.actual_dir),
             expected_dir: Path::new(&json.expected_dir),
@@ -646,7 +686,14 @@ fn walk_images(root: &Path) -> BTreeSet<PathBuf> {
                         sub_prefix.push(&name);
                         stack.push((sub, sub_prefix));
                     }
-                } else if is_supported_extension(Path::new(&name)) {
+                // Ignore macOS AppleDouble resource-fork sidecars. On
+                // non-APFS volumes, writing `foo.png` can create a `._foo.png`
+                // metadata file beside it. It has an image extension but is
+                // not an image, so treating it as one doubles work and can
+                // produce false failures.
+                } else if !name.as_encoded_bytes().starts_with(b"._")
+                    && is_supported_extension(Path::new(&name))
+                {
                     let mut rel = prefix.clone();
                     rel.push(&name);
                     out.push(rel);
@@ -837,5 +884,23 @@ mod per_image_failure_tests {
                 names
             );
         }
+    }
+
+    #[test]
+    fn apple_double_image_sidecars_are_silently_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (actual, expected, diff) = mkdirs(tmp.path());
+
+        fs::write(actual.join("ok.png"), TINY_PNG).unwrap();
+        fs::write(expected.join("ok.png"), TINY_PNG).unwrap();
+        fs::write(actual.join("._ok.png"), b"AppleDouble metadata").unwrap();
+        fs::write(expected.join("._ok.png"), b"different metadata").unwrap();
+
+        let report = run(&actual, &expected, &diff, Options::default()).unwrap();
+
+        assert_eq!(report.passed_items, BTreeSet::from([PathBuf::from("ok.png")]));
+        assert!(report.failed_items.is_empty());
+        assert!(report.actual_items.iter().all(|p| !p.starts_with("._")));
+        assert!(report.expected_items.iter().all(|p| !p.starts_with("._")));
     }
 }

--- a/crates/reg_core/src/report.rs
+++ b/crates/reg_core/src/report.rs
@@ -30,6 +30,10 @@ pub(crate) struct ReportInput<'a> {
     pub(crate) expected_dir: &'a Path,
     pub(crate) diff_dir: &'a Path,
     pub(crate) report: &'a Path,
+    /// Building the self-contained report parses the Mustache template and
+    /// copies the embedded JS/CSS payload. Skip that work unless the caller
+    /// actually requested an HTML report.
+    pub(crate) render_html: bool,
     // extendedErrors: boolean,
     pub(crate) url_prefix: Option<url::Url>,
     pub(crate) enable_client_additional_detection: bool,
@@ -142,6 +146,35 @@ pub fn create_dir_for_json_report<'a>(
 }
 
 pub fn create_reports(input: ReportInput) -> Reports {
+    // The JSON-only path is the common CLI/library case. Move the sets into
+    // the result instead of cloning every PathBuf merely to drop the originals
+    // at the end of this function.
+    if !input.render_html {
+        return Reports {
+            json: JsonReport {
+                failed_items: input.failed,
+                new_items: input.new,
+                deleted_items: input.deleted,
+                passed_items: input.passed,
+                expected_items: input.expected,
+                actual_items: input.actual,
+                diff_items: input.differences,
+                actual_dir: create_dir_for_json_report(
+                    input.json,
+                    input.actual_dir,
+                    input.url_prefix.clone(),
+                ),
+                expected_dir: create_dir_for_json_report(
+                    input.json,
+                    input.expected_dir,
+                    input.url_prefix.clone(),
+                ),
+                diff_dir: create_dir_for_json_report(input.json, input.diff_dir, input.url_prefix),
+            },
+            html: None,
+        };
+    }
+
     let json_report = JsonReport {
         failed_items: input.failed.clone(),
         new_items: input.new.clone(),
@@ -420,6 +453,7 @@ mod tests {
             expected_dir,
             diff_dir,
             report: report_path,
+            render_html: true,
             url_prefix: None,
             enable_client_additional_detection: false,
             from_json: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ const runInternal = async (argv: string[], emitter: EventEmitter): Promise<void>
           if (msg.event) emitter.emit('compare', msg.event);
           return;
         case 'thread-spawn':
-          spawn(msg.startArg, msg.threadId, msg.memory);
+          spawn(msg.startArg, msg.threadId, msg.memory, msg.wasmModule);
           return;
         case 'worker-spans':
           if (Array.isArray(msg.workerSpans)) {
@@ -92,7 +92,12 @@ const runInternal = async (argv: string[], emitter: EventEmitter): Promise<void>
     });
   };
 
-  const spawn = (startArg: number, threadId: Int32Array, memory: WebAssembly.Memory) => {
+  const spawn = (
+    startArg: number,
+    threadId: Int32Array,
+    memory: WebAssembly.Memory,
+    wasmModule: WebAssembly.Module,
+  ) => {
     const t_new_worker = Date.now();
     const w = new Worker(join(dir(), `./runner.${resolveExtention()}`), { workerData: { argv, mode: 'thread' } });
     const tid = nextTid++;
@@ -105,7 +110,7 @@ const runInternal = async (argv: string[], emitter: EventEmitter): Promise<void>
       Atomics.store(threadId, 0, tid);
       Atomics.notify(threadId, 0);
     }
-    w.postMessage({ startArg, tid, memory });
+    w.postMessage({ startArg, tid, memory, wasmModule });
     return tid;
   };
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -44,7 +44,10 @@ const wasi = new WASI({
   printErr,
 });
 
-const wasmFile = readWasm();
+// Only the entry worker reads and compiles the binary. The resulting
+// WebAssembly.Module is structured-cloneable, so Rayon workers can reuse it
+// instead of independently reading and compiling the same module.
+const wasmFile = mode === 'entry' ? readWasm() : null;
 
 const readWasmString = (
   exports: any,
@@ -83,11 +86,17 @@ const makeSpanRecorder = (workerLabel: string) => {
 };
 
 const makeThreadSpawnImport =
-  (memory: WebAssembly.Memory) => (startArg: number) => {
+  (memory: WebAssembly.Memory, wasmModule: WebAssembly.Module) => (startArg: number) => {
     const buf = new SharedArrayBuffer(4);
     const id = new Int32Array(buf);
     Atomics.store(id, 0, -1);
-    parentPort?.postMessage({ cmd: 'thread-spawn', startArg, threadId: id, memory });
+    parentPort?.postMessage({
+      cmd: 'thread-spawn',
+      startArg,
+      threadId: id,
+      memory,
+      wasmModule,
+    });
     Atomics.wait(id, 0, -1);
     return Atomics.load(id, 0);
   };
@@ -96,21 +105,24 @@ const compileAndInstantiate = async (
   memory: WebAssembly.Memory,
   tSpan: ReturnType<typeof makeSpanRecorder>['tSpan'],
   prefix: 'entry' | 'worker',
-): Promise<WebAssembly.Instance> => {
-  const wasm = await tSpan(`${prefix}.wasm_compile`, async () =>
-    WebAssembly.compile(await wasmFile),
-  );
+  compiledModule?: WebAssembly.Module,
+): Promise<{ instance: WebAssembly.Instance; module: WebAssembly.Module }> => {
+  const wasm = compiledModule ?? await tSpan(`${prefix}.wasm_compile`, async () => {
+    if (!wasmFile) throw new Error('Wasm bytes are unavailable in a thread worker');
+    return WebAssembly.compile(await wasmFile);
+  });
   const wasi_snapshot_preview1 = filterWasiImports(
     wasm,
     wasi.getImportObject().wasi_snapshot_preview1,
   );
-  return tSpan(`${prefix}.wasm_instantiate`, async () =>
+  const instance = await tSpan(`${prefix}.wasm_instantiate`, async () =>
     WebAssembly.instantiate(wasm, {
       wasi_snapshot_preview1,
-      wasi: { 'thread-spawn': makeThreadSpawnImport(memory) },
+      wasi: { 'thread-spawn': makeThreadSpawnImport(memory, wasm) },
       env: { memory },
     }),
   );
+  return { instance, module: wasm };
 };
 
 if (mode === 'entry') {
@@ -123,7 +135,7 @@ if (mode === 'entry') {
       maximum: 16384,
       shared: true,
     });
-    const instance = await compileAndInstantiate(memory, tSpan, 'entry');
+    const { instance } = await compileAndInstantiate(memory, tSpan, 'entry');
     const exports = instance.exports as any;
 
     await tSpan('entry.wasi_start', async () => {
@@ -181,16 +193,23 @@ if (mode === 'entry') {
       startArg,
       tid,
       memory,
+      wasmModule,
     }: {
       startArg: number;
       tid: number;
       memory: WebAssembly.Memory;
+      wasmModule: WebAssembly.Module;
     }) => {
       const workerLabel = `thread-${tid}`;
       const handler_start_ms = Date.now();
       const { workerSpans, tSpan } = makeSpanRecorder(workerLabel);
 
-      let instance = await compileAndInstantiate(memory, tSpan, 'worker');
+      let { instance } = await compileAndInstantiate(
+        memory,
+        tSpan,
+        'worker',
+        wasmModule,
+      );
       instance = createInstanceProxy(instance, memory);
 
       await tSpan('worker.wasi_start', async () => {


### PR DESCRIPTION
## Summary

- skip HTML template rendering and PathBuf set cloning unless an HTML report was requested
- compare small batches on the calling thread, while adaptively parallelizing smaller batches of large screenshots
- reuse the entry worker's compiled WebAssembly.Module in Rayon workers
- skip image decoding for byte-identical files and skip diff encoding for differences accepted by reg-cli thresholds
- ignore macOS AppleDouble image sidecars during directory discovery
- update image-diff-rs to the 0.1.2 release and add a representative threshold-accepted benchmark

## Performance

Measured with ten differing 800x578 screenshots accepted by thresholdRate=1:

| Path | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Native reg_core | 327.68 ms | 73.57 ms | 77.5% less time / 4.45x |
| Wasm library E2E median (7 runs) | 625.28 ms | 371.32 ms | 40.6% less time / 1.68x |

The native baseline includes the former unconditional WebP encoding. The adaptive concurrency comparison alone reduced the post-encoding-removal native path from 184.06 ms to 73.57 ms.

For 40 byte-identical images at concurrency 4, sharing the compiled Wasm module reduced median E2E time from about 590 ms to 386.8 ms (about 34%).

## Verification

- cargo test --workspace
- cargo test -p reg_core
- cargo bench -p reg_core --bench run -- threshold_accepted_diffs --noplot
- cargo build --release --target=wasm32-wasip1-threads with wasi-sdk 25
- pnpm build
- node --test test/cli.test.mjs test/library.test.mjs (52 passed)
- node --test test/wasm-oom.test.mjs

The pre-existing modified root reg.wasm and untracked AppleDouble files are intentionally excluded from this PR.
