### PR TITLE
Release 0.19.0-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## @0.19.0-rc2 (5 September, 2026)
+
+- perf(core): avoid diff-image encoding for threshold-accepted changes and adaptively parallelize smaller batches of large screenshots
+- perf(wasm): reuse the compiled WebAssembly module across Rayon workers
+- perf(report): skip HTML rendering and collection cloning when no HTML report is requested
+- fix(core): ignore macOS AppleDouble image sidecars during image discovery
+- deps: update image-diff-rs to 0.1.2
+
 ## @0.19.0-rc1 (5 September, 2026)
 
 - fix(wasm): write diff images as each comparison completes instead of retaining the whole batch in memory, and raise the linear-memory limit from 1 GiB to 4 GiB ([#654](https://github.com/reg-viz/reg-cli/pull/654), [#668](https://github.com/reg-viz/reg-cli/issues/668))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reg-cli",
-  "version": "0.19.0-rc1",
+  "version": "0.19.0-rc2",
   "description": "Visual regression testing CLI, Wasm-backed. Drop-in compatible with classic reg-cli's CLI flags, reg.json/junit schema, and `compare()` EventEmitter API (verified against reg-suit's processor.ts).",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

- bump the npm package version to 0.19.0-rc2
- document the image comparison, Wasm worker, report generation, AppleDouble discovery, and image-diff-rs 0.1.2 changes

## Release verification

The release tarball was built from this exact version commit in a clean worktree:

- Report UI v0.5.0 production build
- wasm32-wasip1-threads release build
- cargo test --workspace (15 passed)
- pnpm test (53 passed, including the large-image Wasm memory regression test)
- tarball smoke install
- reg-cli --version prints 0.19.0-rc2
- ESM package exports compare()

Generated tarball: reg-cli-0.19.0-rc2.tgz, 22 files, 946.9 kB.

Publishing will be performed after this PR is merged. The first publish attempt was rejected before upload because npm requires an OTP; version 0.19.0-rc2 remains unpublished.
