### PR TITLE
perf: use image-diff-rs 0.1.3 count-only path

### DIFF
--- a/crates/reg_core/Cargo.toml
+++ b/crates/reg_core/Cargo.toml
@@ -10,7 +10,7 @@ name = "reg_core"
 path = "src/lib.rs"
 
 [dependencies]
-image-diff-rs = { git = "https://github.com/bokuweb/image-diff-rs.git", tag = "0.1.2" }
+image-diff-rs = { git = "https://github.com/bokuweb/image-diff-rs.git", tag = "0.1.3" }
 rayon = "1.8"
 mustache = "0.9.0"
 serde = { version = "1.0.207", features = ["derive"] }

--- a/crates/reg_core/src/lib.rs
+++ b/crates/reg_core/src/lib.rs
@@ -358,6 +358,33 @@ pub fn run(
                     include_anti_alias: Some(!options.enable_antialias.unwrap_or_default()),
                     encode_format: options.diff_image_format.map(EncodeFormat::from),
                 };
+                // Count without allocating the RGBA visualization when the
+                // acceptance threshold can be evaluated from the count alone.
+                // Rejected comparisons fall through to the existing staged
+                // diff path so their output remains byte-compatible.
+                let count_only_limit = if let Some(threshold) = options.threshold_pixel {
+                    (threshold > 0).then_some(threshold)
+                } else if options.threshold_rate.is_some_and(|rate| rate >= 1.0) {
+                    Some(u64::MAX)
+                } else {
+                    None
+                };
+                if let Some(limit) = count_only_limit {
+                    let diff_count = match image_diff_rs::diff_count(&img1, &img2, &diff_option) {
+                        Ok(count) => count as u64,
+                        Err(e) => {
+                            let path_str = path.display().to_string();
+                            eprintln!("[reg-cli] failed to diff {}: {}", path_str, e);
+                            emit_progress("fail", &path_str);
+                            return Ok((path.to_path_buf(), ImageOutcome::Failed));
+                        }
+                    };
+                    if diff_count <= limit {
+                        emit_progress("pass", &path.to_string_lossy());
+                        return Ok((path.to_path_buf(), ImageOutcome::Passed));
+                    }
+                }
+
                 let rgba = match image_diff_rs::diff_rgba(&img1, &img2, &diff_option) {
                     Ok(r) => r,
                     Err(e) => {


### PR DESCRIPTION
## Summary
- update image-diff-rs from 0.1.2 to 0.1.3
- use the count-only API for accepted pixel-threshold comparisons and fully permissive rate thresholds
- retain the staged RGBA/encode path for rejected comparisons so diff output remains byte-compatible

## Performance
The upstream 800x578 WebP benchmark measured `diff_count` at 16.372 ms versus 19.936 ms for `diff_rgba` (17.9% faster), while avoiding the 1,849,600-byte RGBA visualization allocation per accepted image.

## Validation
- `cargo test -p reg_core --lib` (15 passed)
- `cargo clippy -p reg_core --lib` (new code clean; repository has existing warnings under `-D warnings`)
- built wasm32-wasip1-threads with image-diff-rs 0.1.3
- Node E2E: 52 regular tests passed
- OOM regression test passed standalone (120.6s)
- thresholdRate 0/1 and thresholdPixel 0/10000000 compatibility tests passed

The root `reg.wasm` local modification was intentionally left untouched; validation used the freshly built target artifact staged directly into `dist/reg.wasm`.