### PR TITLE
fix: bundle wasm-util into the worker runner

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -5,4 +5,7 @@ export default defineConfig({
   format: ['esm', 'cjs'],
   dts: true,
   outDir: 'dist',
+  deps: {
+    alwaysBundle: ['@tybys/wasm-util'],
+  },
 });


### PR DESCRIPTION
## Summary

- bundle `@tybys/wasm-util` into the ESM and CommonJS runner outputs
- keep the published dependency metadata unchanged
- make the worker runner independent of a package-manager-created nested symlink at runtime

## Motivation

`src/runner.ts` imports `@tybys/wasm-util`, while tsdown externalizes declared dependencies by default. As a result, the published `dist/runner.mjs` and `dist/runner.cjs` contain a bare package import.

We observed a partially restored `node_modules` cache where the package contents existed but the nested symlink from `reg-cli` was missing. The lockfile and `reg-cli` dependency metadata were correct, but the worker failed at runtime with `ERR_MODULE_NOT_FOUND`. This is related to the stale-install behavior tracked in pnpm/pnpm#12748.

The runner is an internal build artifact, so bundling its WASI implementation dependency makes it self-contained and prevents this failure mode without adding package-manager-specific runtime logic.

## Implementation

Use tsdown's supported `deps.alwaysBundle` option for `@tybys/wasm-util`. Other dependencies remain externalized as before.

## Verification

- built ESM and CommonJS outputs with the repository-pinned pnpm `10.33.3` and tsdown `0.22.2`
- confirmed neither runner output contains a bare `@tybys/wasm-util` import
- ran all 53 tests successfully after removing the installed `node_modules/@tybys/wasm-util` link
- verified the large tall-image regression test still passes
- packed the resulting package and verified ESM CLI and CommonJS `compare()` execution from an isolated pnpm consumer under Node.js 20 with the physical `@tybys/wasm-util` package unavailable

The packed tarball grows from approximately 946 kB to 977 kB, about 30 kB. The ESM and CommonJS runner files each grow by approximately 83 kB uncompressed.
