### PR TITLE
fix(wasm): align Node memory limit with reg.wasm

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -20,6 +20,10 @@ import {
 import { createInstanceProxy } from './proxy';
 import { createPrintErrHook } from './progress';
 import { type RustTraceData, type WorkerSpan } from './tracing';
+import {
+  createSharedWasmMemory,
+  toUnsignedWasmPointer,
+} from './wasm-memory';
 
 type Mode = 'entry' | 'thread';
 const mode: Mode = workerData.mode;
@@ -54,7 +58,7 @@ const readWasmString = (
   memory: WebAssembly.Memory,
   outputPtr: number,
 ): string => {
-  const view = new DataView(memory.buffer, outputPtr);
+  const view = new DataView(memory.buffer, toUnsignedWasmPointer(outputPtr));
   const len = view.getUint32(0, true);
   const bufPtr = view.getUint32(4, true);
   const bytes = new Uint8Array(memory.buffer, bufPtr, len);
@@ -130,11 +134,7 @@ if (mode === 'entry') {
     const entry_start_ms = Date.now();
     const { workerSpans, tSpan } = makeSpanRecorder('entry');
 
-    const memory = new WebAssembly.Memory({
-      initial: 256,
-      maximum: 16384,
-      shared: true,
-    });
+    const memory = createSharedWasmMemory();
     const { instance } = await compileAndInstantiate(memory, tSpan, 'entry');
     const exports = instance.exports as any;
 

--- a/src/wasm-memory.ts
+++ b/src/wasm-memory.ts
@@ -1,0 +1,11 @@
+// Keep the host-created memory aligned with .cargo/config.toml's 4 GiB limit.
+const WASM32_MAX_MEMORY_PAGES = 65_536;
+
+export const createSharedWasmMemory = (): WebAssembly.Memory =>
+  new WebAssembly.Memory({
+    initial: 256,
+    maximum: WASM32_MAX_MEMORY_PAGES,
+    shared: true,
+  });
+
+export const toUnsignedWasmPointer = (pointer: number): number => pointer >>> 0;

--- a/test/wasm-memory.test.mjs
+++ b/test/wasm-memory.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  createSharedWasmMemory,
+  toUnsignedWasmPointer,
+} from '../dist/wasm-memory.mjs';
+
+const WASM_PAGE_SIZE_BYTES = 64 * 1024;
+const INITIAL_MEMORY_PAGES = 256;
+const ONE_GIB_PAGES = 16_384;
+
+test('shared Wasm memory can grow beyond 1 GiB', () => {
+  const memory = createSharedWasmMemory();
+  const initialPages = memory.buffer.byteLength / WASM_PAGE_SIZE_BYTES;
+
+  assert.equal(memory.buffer instanceof SharedArrayBuffer, true);
+  assert.equal(initialPages, INITIAL_MEMORY_PAGES);
+  assert.equal(memory.grow(ONE_GIB_PAGES + 1 - initialPages), initialPages);
+  assert.equal(
+    memory.buffer.byteLength,
+    (ONE_GIB_PAGES + 1) * WASM_PAGE_SIZE_BYTES,
+  );
+
+  const firstByteBeyondOneGib = new Uint8Array(
+    memory.buffer,
+    ONE_GIB_PAGES * WASM_PAGE_SIZE_BYTES,
+    1,
+  );
+  firstByteBeyondOneGib[0] = 1;
+  assert.equal(firstByteBeyondOneGib[0], 1);
+});
+
+test('signed Wasm pointers are converted to unsigned memory offsets', () => {
+  assert.equal(toUnsignedWasmPointer(-2_147_483_648), 2_147_483_648);
+});

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,7 +1,12 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-  entry: ['./src/index.ts', './src/cli.ts', './src/runner.ts'],
+  entry: [
+    './src/index.ts',
+    './src/cli.ts',
+    './src/runner.ts',
+    './src/wasm-memory.ts',
+  ],
   format: ['esm', 'cjs'],
   dts: true,
   outDir: 'dist',


### PR DESCRIPTION
## What does this change?

Align the Node runner's imported shared-memory maximum with the 65,536-page (4 GiB) maximum already declared by `reg.wasm`.

#654 raised the Wasm module's link-time maximum from 16,384 pages (1 GiB) to 65,536 pages, but the Node runner continued to create the imported `WebAssembly.Memory` with a 16,384-page maximum. Since the entry instance and all Rayon workers share that host-created memory, concurrent decode and diff buffers could still exhaust the remaining 1 GiB host-side ceiling.

This change:

- moves shared-memory construction into a small internal module and raises its maximum to 65,536 pages;
- converts exported signed `i32` pointers to unsigned JavaScript memory offsets before reading a report above the 2 GiB boundary;
- adds a deterministic test that grows and accesses the shared memory one page beyond 1 GiB. The test fails with the previous maximum and passes with the new maximum.

The initial memory remains 256 pages (16 MiB), so this does not allocate 4 GiB up front. It only allows the shared memory to grow further when a workload requires it.

This complements #674: that change stopped retaining every encoded diff until the end of a batch, while this change removes the remaining 1 GiB limit for buffers that are concurrently in flight. Wasm32 still has a 4 GiB ceiling, so this does not claim to make arbitrary workloads OOM-safe.

## References

- #654
- #668
- #674

## Screenshots

Not applicable.

## What can I check for bug fixes?

- `pnpm build`
- `pnpm test` (55 tests)
- With the old 16,384-page maximum, `test/wasm-memory.test.mjs` fails with `WebAssembly.Memory.grow(): Maximum memory size exceeded`; with this change it passes on Node.js 20.20.2.
- A real-world 3,261-image comparison at concurrency 15 completes without `memory allocation ... failed` or `RuntimeError: unreachable`, producing 3,031 expected diffs, 230 passes, and complete JSON/HTML artifacts.
